### PR TITLE
Line starting with # is not a comment, fixed to *

### DIFF
--- a/Models/Transistor/BJT/BJT.lib
+++ b/Models/Transistor/BJT/BJT.lib
@@ -1,4 +1,4 @@
-# Unofficial LTSpice Wiki Page: http://ltwiki.org/index.php?title=Standard.dio Date of latest edit	12:47, 24 February 2014
+* Unofficial LTSpice Wiki Page: http://ltwiki.org/index.php?title=Standard.dio Date of latest edit	12:47, 24 February 2014
 
 .model KT940A npn bf=150 is=400f vaf=200 ikf=60m xtb=1.5 br=1 cjc=24p vjc=.75 mjc=.5 fc=.5 cje=50p vje=.75 mje=.33 tr=50n tf=2.5n itf=50m vtf=10 xtf=2 xti=3 eg=1.11 isc=10f nc=2 ise=700p ne=2 rb=30 rbm=3 irb=.1m rc=3 rco=60 Vo=7 GAMMA=1E-6 QCO=1E-11 Vceo=300 Icrating=100m mfg=USSR
 .model kt361g pnp bf=350 br=5 is=400f rb=100 rbm=10 irb=50u rc=10 ikf=70m xti=3 xtb=1.5 xtf=1.1 vaf=70 itf=40m vtf=75 cje=20p xcjc=0.5 cjc=15p tf=0.3n tr=25n vjc=.7 mjc=.33 mje=.33 vje=.5 xcjc=0.15 ne=2 ise=315p nc=2 isc=600p Vceo=35 Icrating=100m mfg=USSR

--- a/Models/Transistor/FET/JFET2.lib
+++ b/Models/Transistor/FET/JFET2.lib
@@ -1,4 +1,4 @@
-# Unofficial LTSpice Wiki Page: http://ltwiki.org/index.php?title=Standard.jft Date of latest edit	02:35, 4 July 2013
+* Unofficial LTSpice Wiki Page: http://ltwiki.org/index.php?title=Standard.jft Date of latest edit	02:35, 4 July 2013
 
 .model kp365 njf vt0=-1.2 beta=10m lambda=0.03 rd=8 rs=8 cgs=4p cgd=5p pb=1 is=50p fc=0. kf=2.f af=1 MFG=USSR
 .model kp302a njf vt0=-2 beta=0.0025 lambda=30m rd=15 rs=3 cgs=12p cgd=25p pb=0.5 is=114.5f fc=0.5 kf=4e-16 af=1 MFG=USSR

--- a/Models/Transistor/FET/MOS.lib
+++ b/Models/Transistor/FET/MOS.lib
@@ -1,4 +1,4 @@
-# Unofficial LTSpice Wiki Page: http://ltwiki.org/index.php?title=Standard.mos Date of latest edit	02:36, 4 July 2013
+* Unofficial LTSpice Wiki Page: http://ltwiki.org/index.php?title=Standard.mos Date of latest edit	02:36, 4 July 2013
 
 .MODEL KP505A VDMOS(KP=3 RS=0.05 RD=0.004 RG=100 Rds=300Meg VTO=1.7 LAMBDA=0.05 CGDMAX=202p CGDMIN=5p CGS=285p TT=720n a=0.25 is=10p n=1.2 Rb=0.21 m=0.368 Vj=1.77 Cjo=185pF mfg=USSR Vds=50 Ron=0.3)
 .MODEL kp505g VDMOS(KP=2.5 RS=0.0022 RD=0.0001 RG=100 Rds=8Meg VTO=0.6 LAMBDA=0.1 CGDMAX=466p CGDMIN=39p CGS=150p TT=720n a=2.59 is=100p n=1.1 Rb=0.12 m=0.437 Vj=0.62 Cjo=160pF mfg=USSR Vds=8 Ron=1)


### PR DESCRIPTION
The simulation failed on a comment line when including BJT.lib .
I corrected the '#' to '*' and it passed.

Ideally this should be checked for all libraries.