### PR TITLE
Fixed some syntactical errors in zener.lib

### DIFF
--- a/Models/Diode/zener.lib
+++ b/Models/Diode/zener.lib
@@ -1,5 +1,4 @@
-*SRC=1N4728A;DI_1N4728A;Diodes;Zener <=10V; 3.30V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4728A;DI_1N4728A;Diodes;Zener <=10V; 3.30V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4728A  1 2
 *        Terminals    A   K
@@ -11,8 +10,7 @@ VZ 2 3 0.972
 .MODEL DR D ( IS=25.0f RS=1.24 N=3.00 )
 .ENDS
 
-*SRC=1N4729A;DI_1N4729A;Diodes;Zener <=10V; 3.60V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4729A;DI_1N4729A;Diodes;Zener <=10V; 3.60V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4729A  1 2
 *        Terminals    A   K
@@ -24,8 +22,7 @@ VZ 2 3 1.30
 .MODEL DR D ( IS=22.9f RS=0.923 N=3.00 )
 .ENDS
 
-*SRC=1N4730A;DI_1N4730A;Diodes;Zener <=10V; 3.90V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4730A;DI_1N4730A;Diodes;Zener <=10V; 3.90V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4730A  1 2
 *        Terminals    A   K
@@ -37,8 +34,7 @@ VZ 2 3 1.63
 .MODEL DR D ( IS=21.1f RS=0.645 N=3.00 )
 .ENDS
 
-*SRC=1N4732A;DI_1N4732A;Diodes;Zener <=10V; 4.70V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4732A;DI_1N4732A;Diodes;Zener <=10V; 4.70V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4732A  1 2
 *        Terminals    A   K
@@ -50,8 +46,7 @@ VZ 2 3 2.99
 .MODEL DR D ( IS=17.5f RS=0.333 N=2.28 )
 .ENDS
 
-*SRC=1N4733A;DI_1N4733A;Diodes;Zener <=10V; 5.10V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4733A;DI_1N4733A;Diodes;Zener <=10V; 5.10V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4733A  1 2
 *        Terminals    A   K
@@ -63,8 +58,7 @@ VZ 2 3 3.69
 .MODEL DR D ( IS=16.2f RS=0.296 N=1.87 )
 .ENDS
 
-*SRC=1N4734A;DI_1N4734A;Diodes;Zener <=10V; 5.60V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4734A;DI_1N4734A;Diodes;Zener <=10V; 5.60V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4734A  1 2
 *        Terminals    A   K
@@ -76,8 +70,7 @@ VZ 2 3 4.48
 .MODEL DR D ( IS=14.7f RS=0.256 N=1.49 )
 .ENDS
 
-*SRC=1N4735A;DI_1N4735A;Diodes;Zener <=10V; 6.20V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4735A;DI_1N4735A;Diodes;Zener <=10V; 6.20V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4735A  1 2
 *        Terminals    A   K
@@ -89,8 +82,7 @@ VZ 2 3 5.33
 .MODEL DR D ( IS=13.3f RS=0.218 N=1.16 )
 .ENDS
 
-*SRC=1N4736A;DI_1N4736A;Diodes;Zener <=10V; 6.80V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4736A;DI_1N4736A;Diodes;Zener <=10V; 6.80V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4736A  1 2
 *        Terminals    A   K
@@ -102,8 +94,7 @@ VZ 2 3 6.05
 .MODEL DR D ( IS=12.1f RS=0.209 N=1.00 )
 .ENDS
 
-*SRC=1N4737A;DI_1N4737A;Diodes;Zener <=10V; 7.50V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4737A;DI_1N4737A;Diodes;Zener <=10V; 7.50V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4737A  1 2
 *        Terminals    A   K
@@ -115,8 +106,7 @@ VZ 2 3 6.68
 .MODEL DR D ( IS=11.0f RS=0.247 N=1.09 )
 .ENDS
 
-*SRC=1N4738A;DI_1N4738A;Diodes;Zener <=10V; 8.20V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4738A;DI_1N4738A;Diodes;Zener <=10V; 8.20V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4738A  1 2
 *        Terminals    A   K
@@ -128,8 +118,7 @@ VZ 2 3 7.33
 .MODEL DR D ( IS=10.0f RS=0.288 N=1.15 )
 .ENDS
 
-*SRC=1N4739A;DI_1N4739A;Diodes;Zener <=10V; 9.10V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4739A;DI_1N4739A;Diodes;Zener <=10V; 9.10V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4739A  1 2
 *        Terminals    A   K
@@ -141,8 +130,7 @@ VZ 2 3 8.16
 .MODEL DR D ( IS=9.05f RS=0.344 N=1.24 )
 .ENDS
 
-*SRC=1N4740A;DI_1N4740A;Diodes;Zener <=10V; 10.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4740A;DI_1N4740A;Diodes;Zener <=10V; 10.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4740A  1 2
 *        Terminals    A   K
@@ -154,8 +142,7 @@ VZ 2 3 9.02
 .MODEL DR D ( IS=8.24f RS=0.403 N=1.30 )
 .ENDS
 
-*SRC=1N4741A;DI_1N4741A;Diodes;Zener 10V-50V; 11.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4741A;DI_1N4741A;Diodes;Zener 10V-50V; 11.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4741A  1 2
 *        Terminals    A   K
@@ -167,8 +154,7 @@ VZ 2 3 9.94
 .MODEL DR D ( IS=7.49f RS=0.474 N=1.41 )
 .ENDS
 
-*SRC=1N4742A;DI_1N4742A;Diodes;Zener 10V-50V; 12.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4742A;DI_1N4742A;Diodes;Zener 10V-50V; 12.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4742A  1 2
 *        Terminals    A   K
@@ -180,8 +166,7 @@ VZ 2 3 10.9
 .MODEL DR D ( IS=6.87f RS=0.550 N=1.49 )
 .ENDS
 
-*SRC=1N4743A;DI_1N4743A;Diodes;Zener 10V-50V; 13.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4743A;DI_1N4743A;Diodes;Zener 10V-50V; 13.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4743A  1 2
 *        Terminals    A   K
@@ -193,8 +178,7 @@ VZ 2 3 11.8
 .MODEL DR D ( IS=6.34f RS=0.630 N=1.55 )
 .ENDS
 
-*SRC=1N4744A;DI_1N4744A;Diodes;Zener 10V-50V; 15.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4744A;DI_1N4744A;Diodes;Zener 10V-50V; 15.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4744A  1 2
 *        Terminals    A   K
@@ -206,8 +190,7 @@ VZ 2 3 13.7
 .MODEL DR D ( IS=5.49f RS=0.804 N=1.77 )
 .ENDS
 
-*SRC=1N4745A;DI_1N4745A;Diodes;Zener 10V-50V; 16.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4745A;DI_1N4745A;Diodes;Zener 10V-50V; 16.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4745A  1 2
 *        Terminals    A   K
@@ -219,8 +202,7 @@ VZ 2 3 14.6
 .MODEL DR D ( IS=5.15f RS=0.897 N=1.80 )
 .ENDS
 
-*SRC=1N4746A;DI_1N4746A;Diodes;Zener 10V-50V; 18.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4746A;DI_1N4746A;Diodes;Zener 10V-50V; 18.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4746A  1 2
 *        Terminals    A   K
@@ -232,8 +214,7 @@ VZ 2 3 16.5
 .MODEL DR D ( IS=4.58f RS=1.10 N=1.98 )
 .ENDS
 
-*SRC=1N4747A;DI_1N4747A;Diodes;Zener 10V-50V; 20.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4747A;DI_1N4747A;Diodes;Zener 10V-50V; 20.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4747A  1 2
 *        Terminals    A   K
@@ -245,8 +226,7 @@ VZ 2 3 18.4
 .MODEL DR D ( IS=4.12f RS=1.31 N=2.12 )
 .ENDS
 
-*SRC=1N4748A;DI_1N4748A;Diodes;Zener 10V-50V; 22.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4748A;DI_1N4748A;Diodes;Zener 10V-50V; 22.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4748A  1 2
 *        Terminals    A   K
@@ -258,8 +238,7 @@ VZ 2 3 20.3
 .MODEL DR D ( IS=3.75f RS=1.54 N=2.29 )
 .ENDS
 
-*SRC=1N4749A;DI_1N4749A;Diodes;Zener 10V-50V; 24.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4749A;DI_1N4749A;Diodes;Zener 10V-50V; 24.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4749A  1 2
 *        Terminals    A   K
@@ -271,8 +250,7 @@ VZ 2 3 22.2
 .MODEL DR D ( IS=3.43f RS=1.79 N=2.42 )
 .ENDS
 
-*SRC=1N4750A;DI_1N4750A;Diodes;Zener 10V-50V; 27.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4750A;DI_1N4750A;Diodes;Zener 10V-50V; 27.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4750A  1 2
 *        Terminals    A   K
@@ -284,8 +262,7 @@ VZ 2 3 25.0
 .MODEL DR D ( IS=3.05f RS=2.18 N=2.68 )
 .ENDS
 
-*SRC=1N4751A;DI_1N4751A;Diodes;Zener 10V-50V; 30.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4751A;DI_1N4751A;Diodes;Zener 10V-50V; 30.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4751A  1 2
 *        Terminals    A   K
@@ -297,8 +274,7 @@ VZ 2 3 27.8
 .MODEL DR D ( IS=2.75f RS=2.61 N=2.87 )
 .ENDS
 
-*SRC=1N4752A;DI_1N4752A;Diodes;Zener 10V-50V; 33.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4752A;DI_1N4752A;Diodes;Zener 10V-50V; 33.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4752A  1 2
 *        Terminals    A   K
@@ -310,8 +286,7 @@ VZ 2 3 30.8
 .MODEL DR D ( IS=2.50f RS=3.07 N=2.98 )
 .ENDS
 
-*SRC=1N4753A;DI_1N4753A;Diodes;Zener 10V-50V; 36.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4753A;DI_1N4753A;Diodes;Zener 10V-50V; 36.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4753A  1 2
 *        Terminals    A   K
@@ -323,8 +298,7 @@ VZ 2 3 33.7
 .MODEL DR D ( IS=2.29f RS=4.38 N=3.00 )
 .ENDS
 
-*SRC=1N4754A;DI_1N4754A;Diodes;Zener 10V-50V; 39.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4754A;DI_1N4754A;Diodes;Zener 10V-50V; 39.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4754A  1 2
 *        Terminals    A   K
@@ -336,8 +310,7 @@ VZ 2 3 36.7
 .MODEL DR D ( IS=2.11f RS=5.78 N=3.00 )
 .ENDS
 
-*SRC=1N4755A;DI_1N4755A;Diodes;Zener 10V-50V; 43.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4755A;DI_1N4755A;Diodes;Zener 10V-50V; 43.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4755A  1 2
 *        Terminals    A   K
@@ -349,8 +322,7 @@ VZ 2 3 40.7
 .MODEL DR D ( IS=1.92f RS=7.99 N=3.00 )
 .ENDS
 
-*SRC=1N4756A;DI_1N4756A;Diodes;Zener 10V-50V; 47.0V  1.00W   Diodes Inc.
-Zener
+*SRC=1N4756A;DI_1N4756A;Diodes;Zener 10V-50V; 47.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N4756A  1 2
 *        Terminals    A   K
@@ -458,7 +430,7 @@ VZ 2 3 97.6
 .MODEL DR D ( IS=8.24e-016 RS=56.8 N=3.00 )
 .ENDS
 
-*SRC=1N5221B;DI_1N5221B;Diodes;Zener <=10V; 2.40V  0.500W   DIODES INC ZENER
+*SRC=1N5221B;DI_1N5221B;Diodes;Zener <=10V; 2.40V  0.500W   Diodes Inc ZENER
 *SYM=HZEN
 .SUBCKT DI_1N5221B  1 2
 *        Terminals    A   K
@@ -470,8 +442,7 @@ VZ 2 3 0
 .MODEL DR D ( IS=17.2f RS=26.1 N=3.00 )
 .ENDS
 
-*SRC=1N5231B;DI_1N5231B;Diodes;Zener <=10V; 5.10V  0.500W   Diodes Inc.
-zener
+*SRC=1N5231B;DI_1N5231B;Diodes;Zener <=10V; 5.10V  0.500W   Diodes Inc. zener
 *SYM=HZEN
 .SUBCKT DI_1N5231B  1 2
 *        Terminals    A   K
@@ -483,32 +454,31 @@ VZ 2 3 2.62
 .MODEL DR D ( IS=8.08f RS=13.1 N=3.00 )
 .ENDS
 
-*SRC=1N5233B;DI_1N5233B;Diodes;Zener <=10V; 6.00V  0.500W   Diodes Inc. Zener 
-*SYM=HZEN 
-.SUBCKT DI_1N5233B  1 2 
-*        Terminals    A   K 
-D1 1 2 DF 
-DZ 3 1 DR 
-VZ 2 3 5.11 
-.MODEL DF D ( IS=34.3p RS=1.24 N=1.10 
-+ CJO=74.2p VJ=0.750 M=0.330 TT=50.1n ) 
-.MODEL DR D ( IS=6.87f RS=0.460 N=1.19 ) 
+*SRC=1N5233B;DI_1N5233B;Diodes;Zener <=10V; 6.00V  0.500W   Diodes Inc. Zener
+*SYM=HZEN
+.SUBCKT DI_1N5233B  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 5.11
+.MODEL DF D ( IS=34.3p RS=1.24 N=1.10
++ CJO=74.2p VJ=0.750 M=0.330 TT=50.1n )
+.MODEL DR D ( IS=6.87f RS=0.460 N=1.19 )
 .ENDS
 
-*SRC=1N5235B;DI_1N5235B;Diodes;Zener <=10V; 6.80V  0.500W   Diodes Inc. Zener 
-*SYM=HZEN 
-.SUBCKT DI_1N5235B  1 2 
-*        Terminals    A   K 
-D1 1 2 DF 
-DZ 3 1 DR 
-VZ 2 3 4.56 
-.MODEL DF D ( IS=30.3p RS=1.24 N=1.10 
-+ CJO=61.5p VJ=0.750 M=0.330 TT=50.1n ) 
-.MODEL DR D ( IS=6.06f RS=1.15 N=2.97 ) 
+*SRC=1N5235B;DI_1N5235B;Diodes;Zener <=10V; 6.80V  0.500W   Diodes Inc. Zener
+*SYM=HZEN
+.SUBCKT DI_1N5235B  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 4.56
+.MODEL DF D ( IS=30.3p RS=1.24 N=1.10
++ CJO=61.5p VJ=0.750 M=0.330 TT=50.1n )
+.MODEL DR D ( IS=6.06f RS=1.15 N=2.97 )
 .ENDS
 
-*SRC=1N5239B;DI_1N5239B;Diodes;Zener <=10V; 9.10V  0.500W   Diodes Inc.
-Zener
+*SRC=1N5239B;DI_1N5239B;Diodes;Zener <=10V; 9.10V  0.500W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_1N5239B  1 2
 *        Terminals    A   K
@@ -520,16 +490,16 @@ VZ 2 3 6.72
 .MODEL DR D ( IS=4.53f RS=6.11 N=3.00 )
 .ENDS
 
-*SRC=1N5241B;DI_1N5241B;Diodes;Zener 10V-50V; 11.0V  0.500W   Diodes Inc. Zener 
-*SYM=HZEN 
-.SUBCKT DI_1N5241B  1 2 
-*        Terminals    A   K 
-D1 1 2 DF 
-DZ 3 1 DR 
-VZ 2 3 9.12 
-.MODEL DF D ( IS=18.7p RS=1.24 N=1.10 
-+ CJO=58.2p VJ=1.00 M=0.330 TT=50.1n ) 
-.MODEL DR D ( IS=3.75f RS=0.949 N=2.45 ) 
+*SRC=1N5241B;DI_1N5241B;Diodes;Zener 10V-50V; 11.0V  0.500W   Diodes Inc. Zener
+*SYM=HZEN
+.SUBCKT DI_1N5241B  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 9.12
+.MODEL DF D ( IS=18.7p RS=1.24 N=1.10
++ CJO=58.2p VJ=1.00 M=0.330 TT=50.1n )
+.MODEL DR D ( IS=3.75f RS=0.949 N=2.45 )
 .ENDS
 
 *SRC=AZ23C10;DI_AZ23C10;Diodes;Zener <=10V; 10.0V  0.300W   Diodes Inc. Per node.  Device contains two
@@ -541,6 +511,8 @@ DZ 3 1 DR
 VZ 2 3 8.35
 .MODEL DF D ( IS=12.4p RS=31.6 N=1.10
 + CJO=46.3p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C10W;DI_AZ23C10W;Diodes;Zener <=10V; 10.0V  0.200W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -552,6 +524,8 @@ VZ 2 3 8.32
 .MODEL DF D ( IS=8.24p RS=30.4 N=1.10
 + CJO=46.3p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=1.65f RS=3.45 N=2.23 )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C11;DI_AZ23C11;Diodes;Zener 10V-50V; 11.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -562,6 +536,8 @@ DZ 3 1 DR
 VZ 2 3 8.79
 .MODEL DF D ( IS=11.2p RS=31.3 N=1.10
 + CJO=41.5p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C12;DI_AZ23C12;Diodes;Zener 10V-50V; 12.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -572,6 +548,8 @@ DZ 3 1 DR
 VZ 2 3 9.78
 .MODEL DF D ( IS=10.3p RS=31.0 N=1.10
 + CJO=39.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C13;DI_AZ23C13;Diodes;Zener 10V-50V; 13.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -582,6 +560,8 @@ DZ 3 1 DR
 VZ 2 3 10.7
 .MODEL DF D ( IS=9.51p RS=30.8 N=1.10
 + CJO=37.7p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C15;DI_AZ23C15;Diodes;Zener 10V-50V; 15.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -592,6 +572,8 @@ DZ 3 1 DR
 VZ 2 3 12.7
 .MODEL DF D ( IS=8.24p RS=30.4 N=1.10
 + CJO=31.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C16;DI_AZ23C16;Diodes;Zener 10V-50V; 16.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -602,6 +584,8 @@ DZ 3 1 DR
 VZ 2 3 13.6
 .MODEL DF D ( IS=7.72p RS=30.2 N=1.10
 + CJO=30.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C18;DI_AZ23C18;Diodes;Zener 10V-50V; 18.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -612,6 +596,8 @@ DZ 3 1 DR
 VZ 2 3 15.6
 .MODEL DF D ( IS=6.87p RS=29.9 N=1.10
 + CJO=26.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C18W;DI_AZ23C18W;Diodes;Zener 10V-50V; 18.0V  0.200W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -623,6 +609,8 @@ VZ 2 3 15.5
 .MODEL DF D ( IS=4.58p RS=28.7 N=1.10
 + CJO=26.4p VJ=1.00 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=9.16e-016 RS=34.5 N=3.00 )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C20;DI_AZ23C20;Diodes;Zener 10V-50V; 20.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -633,6 +621,8 @@ DZ 3 1 DR
 VZ 2 3 17.6
 .MODEL DF D ( IS=6.18p RS=29.6 N=1.10
 + CJO=23.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C22;DI_AZ23C22;Diodes;Zener 10V-50V; 22.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -643,6 +633,8 @@ DZ 3 1 DR
 VZ 2 3 19.5
 .MODEL DF D ( IS=5.62p RS=29.3 N=1.10
 + CJO=22.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C24;DI_AZ23C24;Diodes;Zener 10V-50V; 24.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -653,6 +645,8 @@ DZ 3 1 DR
 VZ 2 3 21.4
 .MODEL DF D ( IS=5.15p RS=29.1 N=1.10
 + CJO=21.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C27;DI_AZ23C27;Diodes;Zener 10V-50V; 27.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -663,6 +657,8 @@ DZ 3 1 DR
 VZ 2 3 24.4
 .MODEL DF D ( IS=4.58p RS=28.7 N=1.10
 + CJO=20.7p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C2V7;DI_AZ23C2V7;Diodes;Zener <=10V; 2.70V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -673,6 +669,8 @@ DZ 3 1 DR
 VZ 2 3 0.263
 .MODEL DF D ( IS=45.8p RS=35.3 N=1.10
 + CJO=450p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C30;DI_AZ23C30;Diodes;Zener 10V-50V; 30.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -683,6 +681,8 @@ DZ 3 1 DR
 VZ 2 3 27.4
 .MODEL DF D ( IS=4.12p RS=28.4 N=1.10
 + CJO=19.5p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C33;DI_AZ23C33;Diodes;Zener 10V-50V; 33.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -693,6 +693,8 @@ DZ 3 1 DR
 VZ 2 3 30.4
 .MODEL DF D ( IS=3.75p RS=28.2 N=1.10
 + CJO=18.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C36;DI_AZ23C36;Diodes;Zener 10V-50V; 36.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -703,6 +705,8 @@ DZ 3 1 DR
 VZ 2 3 33.3
 .MODEL DF D ( IS=3.43p RS=27.9 N=1.10
 + CJO=17.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C39;DI_AZ23C39;Diodes;Zener 10V-50V; 39.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -713,6 +717,8 @@ DZ 3 1 DR
 VZ 2 3 36.3
 .MODEL DF D ( IS=3.17p RS=27.7 N=1.10
 + CJO=17.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C3V0;DI_AZ23C3V0;Diodes;Zener <=10V; 3.00V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -723,6 +729,8 @@ DZ 3 1 DR
 VZ 2 3 0.495
 .MODEL DF D ( IS=41.2p RS=35.0 N=1.10
 + CJO=417p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C3V3;DI_AZ23C3V3;Diodes;Zener <=10V; 3.30V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -733,6 +741,8 @@ DZ 3 1 DR
 VZ 2 3 0.787
 .MODEL DF D ( IS=37.5p RS=34.7 N=1.10
 + CJO=397p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C3V6;DI_AZ23C3V6;Diodes;Zener <=10V; 3.60V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -743,6 +753,8 @@ DZ 3 1 DR
 VZ 2 3 1.08
 .MODEL DF D ( IS=34.3p RS=34.5 N=1.10
 + CJO=384p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C3V9;DI_AZ23C3V9;Diodes;Zener <=10V; 3.60V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -753,6 +765,8 @@ DZ 3 1 DR
 VZ 2 3 1.08
 .MODEL DF D ( IS=34.3p RS=34.5 N=1.10
 + CJO=370p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C43;DI_AZ23C43;Diodes;Zener 10V-50V; 43.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -763,6 +777,8 @@ DZ 3 1 DR
 VZ 2 3 40.3
 .MODEL DF D ( IS=2.87p RS=27.4 N=1.10
 + CJO=16.7p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C47;DI_AZ23C47;Diodes;Zener 10V-50V; 47.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -773,6 +789,8 @@ DZ 3 1 DR
 VZ 2 3 44.3
 .MODEL DF D ( IS=2.63p RS=27.2 N=1.10
 + CJO=16.3p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C4V3;DI_AZ23C4V3;Diodes;Zener <=10V; 4.30V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -783,6 +801,8 @@ DZ 3 1 DR
 VZ 2 3 1.77
 .MODEL DF D ( IS=28.7p RS=34.0 N=1.10
 + CJO=357p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C4V7;DI_AZ23C4V7;Diodes;Zener <=10V; 4.70V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -793,6 +813,8 @@ DZ 3 1 DR
 VZ 2 3 2.24
 .MODEL DF D ( IS=26.3p RS=33.7 N=1.10
 + CJO=350p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C51;DI_AZ23C51;Diodes;Zener >50V; 51.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -803,6 +825,8 @@ DZ 3 1 DR
 VZ 2 3 48.2
 .MODEL DF D ( IS=2.42p RS=26.9 N=1.10
 + CJO=16.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C5V1;DI_AZ23C5V1;Diodes;Zener <=10V; 5.10V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -813,6 +837,8 @@ DZ 3 1 DR
 VZ 2 3 2.73
 .MODEL DF D ( IS=24.2p RS=33.5 N=1.10
 + CJO=132p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C5V6;DI_AZ23C5V6;Diodes;Zener <=10V; 5.60V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -823,6 +849,8 @@ DZ 3 1 DR
 VZ 2 3 3.32
 .MODEL DF D ( IS=22.1p RS=33.2 N=1.10
 + CJO=102p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C5V6W;DI_AZ23C5V6W;Diodes;Zener <=10V; 5.60V  0.200W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -834,6 +862,8 @@ VZ 2 3 3.29
 .MODEL DF D ( IS=14.7p RS=32.1 N=1.10
 + CJO=102p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=2.94f RS=24.5 N=3.00 )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C6V2;DI_AZ23C6V2;Diodes;Zener <=10V; 6.20V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -844,6 +874,8 @@ DZ 3 1 DR
 VZ 2 3 5.12
 .MODEL DF D ( IS=19.9p RS=32.9 N=1.10
 + CJO=79.4p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C6V8;DI_AZ23C6V8;Diodes;Zener <=10V; 6.80V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -854,6 +886,8 @@ DZ 3 1 DR
 VZ 2 3 5.93
 .MODEL DF D ( IS=18.2p RS=32.7 N=1.10
 + CJO=72.7p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C6V8W;DI_AZ23C6V8W;Diodes;Zener <=10V; 6.80V  0.200W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -865,6 +899,8 @@ VZ 2 3 5.15
 .MODEL DF D ( IS=12.1p RS=31.5 N=1.10
 + CJO=72.7p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=2.42f RS=3.45 N=2.23 )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C7V5;DI_AZ23C7V5;Diodes;Zener <=10V; 7.50V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -875,6 +911,8 @@ DZ 3 1 DR
 VZ 2 3 6.74
 .MODEL DF D ( IS=16.5p RS=32.4 N=1.10
 + CJO=59.5p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C8V2;DI_AZ23C8V2;Diodes;Zener <=10V; 8.20V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -885,6 +923,8 @@ DZ 3 1 DR
 VZ 2 3 7.43
 .MODEL DF D ( IS=15.1p RS=32.1 N=1.10
 + CJO=54.2p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=AZ23C9V1;DI_AZ23C9V1;Diodes;Zener <=10V; 9.10V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -895,17 +935,19 @@ DZ 3 1 DR
 VZ 2 3 8.00
 .MODEL DF D ( IS=13.6p RS=31.8 N=1.10
 + CJO=48.9p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZT52C10;DI_BZT52C10;Diodes;Zener <=10V; 10.0V  0.500W   Diodes Inc. Zener 
-*SYM=HZEN 
-.SUBCKT DI_BZT52C10  1 2 
-*        Terminals    A   K 
-D1 1 2 DF 
-DZ 3 1 DR 
-VZ 2 3 7.84 
-.MODEL DF D ( IS=20.6p RS=1.22 N=1.10 
-+ CJO=45.6p VJ=0.750 M=0.330 TT=50.1n ) 
-.MODEL DR D ( IS=4.12f RS=4.60 N=2.97 ) 
+*SRC=BZT52C10;DI_BZT52C10;Diodes;Zener <=10V; 10.0V  0.500W   Diodes Inc. Zener
+*SYM=HZEN
+.SUBCKT DI_BZT52C10  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 7.84
+.MODEL DF D ( IS=20.6p RS=1.22 N=1.10
++ CJO=45.6p VJ=0.750 M=0.330 TT=50.1n )
+.MODEL DR D ( IS=4.12f RS=4.60 N=2.97 )
 .ENDS
 
 *SRC=BZT52C10S;DI_BZT52C10S;Diodes;Zener <=10V; 10.0V  0.200W   Diodes Inc. ZENER
@@ -917,9 +959,10 @@ DZ 3 1 DR
 VZ 2 3 7.76
 .MODEL DF D ( IS=8.24p RS=30.4 N=1.10
 + CJO=47.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C11;DI_BZT52C11;Diodes;Zener 10V-50V; 11.0V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C11  1 2
 *        Terminals    A   K
@@ -929,6 +972,8 @@ VZ 2 3 8.83
 .MODEL DF D ( IS=18.7p RS=32.7 N=1.10
 + CJO=44.0p VJ=1.00 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=3.75f RS=4.60 N=2.97
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C11S;DI_BZT52C11S;Diodes;Zener 10V-50V; 11.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -939,9 +984,10 @@ DZ 3 1 DR
 VZ 2 3 8.76
 .MODEL DF D ( IS=7.49p RS=30.1 N=1.10
 + CJO=44.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C12;DI_BZT52C12;Diodes;Zener 10V-50V; 12.0V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C12  1 2
 *        Terminals    A   K
@@ -951,6 +997,8 @@ VZ 2 3 9.78
 .MODEL DF D ( IS=17.2p RS=32.5 N=1.10
 + CJO=42.7p VJ=1.00 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=3.43f RS=9.46 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C12S;DI_BZT52C12S;Diodes;Zener 10V-50V; 12.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -961,17 +1009,19 @@ DZ 3 1 DR
 VZ 2 3 9.71
 .MODEL DF D ( IS=6.87p RS=29.9 N=1.10
 + CJO=42.7p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZT52C13;DI_BZT52C13;Diodes;Zener 10V-50V; 13.0V  0.500W   Diodes Inc. Zener 
-*SYM=HZEN 
-.SUBCKT DI_BZT52C13  1 2 
-*        Terminals    A   K 
-D1 1 2 DF 
-DZ 3 1 DR 
-VZ 2 3 12.4 
-.MODEL DF D ( IS=15.8p RS=1.24 N=1.10 
-+ CJO=51.5p VJ=1.00 M=0.330 TT=50.1n ) 
-.MODEL DR D ( IS=3.17f RS=1.26 N=0.814 ) 
+*SRC=BZT52C13;DI_BZT52C13;Diodes;Zener 10V-50V; 13.0V  0.500W   Diodes Inc. Zener
+*SYM=HZEN
+.SUBCKT DI_BZT52C13  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 12.4
+.MODEL DF D ( IS=15.8p RS=1.24 N=1.10
++ CJO=51.5p VJ=1.00 M=0.330 TT=50.1n )
+.MODEL DR D ( IS=3.17f RS=1.26 N=0.814 )
 .ENDS
 
 *SRC=BZT52C13S;DI_BZT52C13S;Diodes;Zener 10V-50V; 13.0V  0.200W   Diodes Inc. ZENER
@@ -983,9 +1033,10 @@ DZ 3 1 DR
 VZ 2 3 10.7
 .MODEL DF D ( IS=6.34p RS=29.7 N=1.10
 + CJO=25.8p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C15;DI_BZT52C15;Diodes;Zener 10V-50V; 15.0V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C15  1 2
 *        Terminals    A   K
@@ -995,6 +1046,8 @@ VZ 2 3 12.7
 .MODEL DF D ( IS=13.7p RS=31.9 N=1.10
 + CJO=32.7p VJ=1.00 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=2.75f RS=14.5 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C15S;DI_BZT52C15S;Diodes;Zener 10V-50V; 15.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1005,9 +1058,10 @@ DZ 3 1 DR
 VZ 2 3 12.7
 .MODEL DF D ( IS=5.49p RS=29.3 N=1.10
 + CJO=25.5p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C16;DI_BZT52C16;Diodes;Zener 10V-50V; 16.0V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C16  1 2
 *        Terminals    A   K
@@ -1017,6 +1071,8 @@ VZ 2 3 13.7
 .MODEL DF D ( IS=12.9p RS=31.7 N=1.10
 + CJO=31.4p VJ=1.00 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=2.58f RS=24.5 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C16S;DI_BZT52C16S;Diodes;Zener 10V-50V; 16.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1027,9 +1083,10 @@ DZ 3 1 DR
 VZ 2 3 13.6
 .MODEL DF D ( IS=5.15p RS=29.1 N=1.10
 + CJO=25.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C18;DI_BZT52C18;Diodes;Zener 10V-50V; 18.0V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C18  1 2
 *        Terminals    A   K
@@ -1039,8 +1096,9 @@ VZ 2 3 15.6
 .MODEL DF D ( IS=11.4p RS=31.3 N=1.10
 + CJO=27.7p VJ=1.00 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=2.29f RS=29.5 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-**********************************************************************************************************************************
 *SRC=BZT52C18S;DI_BZT52C18S;Diodes;Zener 10V-50V; 18.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
 .SUBCKT DI_BZT52C18S  1 2
@@ -1052,10 +1110,8 @@ VZ 2 3 15.6
 + CJO=25.3p VJ=1.00 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=9.16e-016 RS=29.5 N=3.00 )
 .ENDS
-*********************************************************************************************************************************
 
 *SRC=BZT52C20;DI_BZT52C20;Diodes;Zener 10V-50V; 20.0V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C20  1 2
 *        Terminals    A   K
@@ -1065,6 +1121,8 @@ VZ 2 3 17.6
 .MODEL DF D ( IS=10.3p RS=31.0 N=1.10
 + CJO=23.9p VJ=1.00 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=2.06f RS=39.5 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C20S;DI_BZT52C20S;Diodes;Zener 10V-50V; 20.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1075,9 +1133,10 @@ DZ 3 1 DR
 VZ 2 3 17.5
 .MODEL DF D ( IS=4.12p RS=28.4 N=1.10
 + CJO=23.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C22;DI_BZT52C22;Diodes;Zener 10V-50V; 22.0V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C22  1 2
 *        Terminals    A   K
@@ -1087,6 +1146,8 @@ VZ 2 3 19.6
 .MODEL DF D ( IS=9.36p RS=30.8 N=1.10
 + CJO=22.6p VJ=1.00 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=1.87f RS=39.5 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C22S;DI_BZT52C22S;Diodes;Zener 10V-50V; 22.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1097,9 +1158,10 @@ DZ 3 1 DR
 VZ 2 3 19.5
 .MODEL DF D ( IS=3.75p RS=28.2 N=1.10
 + CJO=22.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C24;DI_BZT52C24;Diodes;Zener 10V-50V; 24.0V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C24  1 2
 *        Terminals    A   K
@@ -1109,6 +1171,8 @@ VZ 2 3 21.5
 .MODEL DF D ( IS=8.58p RS=30.5 N=1.10
 + CJO=21.4p VJ=1.00 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=1.72f RS=54.5 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C24S;DI_BZT52C24S;Diodes;Zener 10V-50V; 24.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1119,9 +1183,10 @@ DZ 3 1 DR
 VZ 2 3 21.4
 .MODEL DF D ( IS=3.43p RS=27.9 N=1.10
 + CJO=21.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C27;DI_BZT52C27;Diodes;Zener 10V-50V; 27.0V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C27  1 2
 *        Terminals    A   K
@@ -1131,6 +1196,8 @@ VZ 2 3 24.7
 .MODEL DF D ( IS=7.63p RS=30.2 N=1.10
 + CJO=20.1p VJ=1.00 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=1.53f RS=41.1 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C27S;DI_BZT52C27S;Diodes;Zener 10V-50V; 27.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1141,6 +1208,8 @@ DZ 3 1 DR
 VZ 2 3 24.7
 .MODEL DF D ( IS=3.05p RS=27.6 N=1.10
 + CJO=20.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C2V0;DI_BZT52C2V0;Diodes;Zener <=10V; 2.00V  0.500W   Diodes Inc.
 *SYM=HZEN
@@ -1152,6 +1221,8 @@ VZ 2 3 0
 .MODEL DF D ( IS=103p RS=37.6 N=1.10
 + CJO=516p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=20.6f RS=84.5 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C2V0S;DI_BZT52C2V0S;Diodes;Zener <=10V; 2.00V  0.200W   Diodes Inc. 200 mW Zener
 *SYM=HZEN
@@ -1162,8 +1233,10 @@ DZ 3 1 DR
 VZ 2 3 0
 .MODEL DF D ( IS=41.2p RS=35.0 N=1.10
 + CJO=503p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZT52C2V4;DI_BZT52C2V4;Diodes;Zener <=10V; 2.40V  0.500W   Diodes Inc. 
+*SRC=BZT52C2V4;DI_BZT52C2V4;Diodes;Zener <=10V; 2.40V  0.500W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZT52C2V4  1 2
 *        Terminals    A   K
@@ -1184,6 +1257,8 @@ DZ 3 1 DR
 VZ 2 3 0
 .MODEL DF D ( IS=34.3p RS=34.5 N=1.10
 + CJO=460p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C2V7;DI_BZT52C2V7;Diodes;Zener <=10V; 2.70V  0.500W   Diodes Inc. -
 *SYM=HZEN
@@ -1206,9 +1281,10 @@ DZ 3 1 DR
 VZ 2 3 0.146
 .MODEL DF D ( IS=30.5p RS=34.1 N=1.10
 + CJO=410p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C30;DI_BZT52C30;Diodes;Zener 10V-50V; 30.0V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C30  1 2
 *        Terminals    A   K
@@ -1218,6 +1294,8 @@ VZ 2 3 27.7
 .MODEL DF D ( IS=6.87p RS=29.9 N=1.10
 + CJO=18.9p VJ=1.00 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=1.37f RS=41.1 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C30S;DI_BZT52C30S;Diodes;Zener 10V-50V; 30.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1228,9 +1306,10 @@ DZ 3 1 DR
 VZ 2 3 27.7
 .MODEL DF D ( IS=2.75p RS=27.3 N=1.10
 + CJO=18.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C33;DI_BZT52C33;Diodes;Zener 10V-50V; 33.0V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C33  1 2
 *        Terminals    A   K
@@ -1240,6 +1319,8 @@ VZ 2 3 30.7
 .MODEL DF D ( IS=6.24p RS=29.6 N=1.10
 + CJO=17.6p VJ=1.00 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=1.25f RS=41.1 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C33S;DI_BZT52C33S;Diodes;Zener 10V-50V; 33.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1250,17 +1331,19 @@ DZ 3 1 DR
 VZ 2 3 30.7
 .MODEL DF D ( IS=2.50p RS=27.0 N=1.10
 + CJO=17.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZT52C36;DI_BZT52C36;Diodes;Zener 10V-50V; 36.0V  0.500W   Diodes Inc. Zener 
-*SYM=HZEN 
-.SUBCKT DI_BZT52C36  1 2 
-*        Terminals    A   K 
-D1 1 2 DF 
-DZ 3 1 DR 
-VZ 2 3 33.7 
-.MODEL DF D ( IS=5.72p RS=1.27 N=1.10 
-+ CJO=18.9p VJ=1.00 M=0.330 TT=50.1n ) 
-.MODEL DR D ( IS=1.14f RS=51.1 N=3.00 ) 
+*SRC=BZT52C36;DI_BZT52C36;Diodes;Zener 10V-50V; 36.0V  0.500W   Diodes Inc. Zener
+*SYM=HZEN
+.SUBCKT DI_BZT52C36  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 33.7
+.MODEL DF D ( IS=5.72p RS=1.27 N=1.10
++ CJO=18.9p VJ=1.00 M=0.330 TT=50.1n )
+.MODEL DR D ( IS=1.14f RS=51.1 N=3.00 )
 .ENDS
 
 *SRC=BZT52C36S;DI_BZT52C36S;Diodes;Zener 10V-50V; 36.0V  0.200W   Diodes Inc. ZENER
@@ -1272,9 +1355,10 @@ DZ 3 1 DR
 VZ 2 3 33.7
 .MODEL DF D ( IS=2.29p RS=26.8 N=1.10
 + CJO=17.3p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C39;DI_BZT52C39;Diodes;Zener 10V-50V; 39.0V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C39  1 2
 *        Terminals    A   K
@@ -1284,6 +1368,8 @@ VZ 2 3 36.6
 .MODEL DF D ( IS=5.28p RS=29.1 N=1.10
 + CJO=16.3p VJ=1.00 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=1.06f RS=91.1 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C39S;DI_BZT52C39S;Diodes;Zener 10V-50V; 39.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1294,6 +1380,8 @@ DZ 3 1 DR
 VZ 2 3 36.5
 .MODEL DF D ( IS=2.11p RS=26.5 N=1.10
 + CJO=16.3p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C3V0;DI_BZT52C3V0;Diodes;Zener <=10V; 3.00V  0.500W   Diodes Inc. -
 *SYM=HZEN
@@ -1316,9 +1404,10 @@ DZ 3 1 DR
 VZ 2 3 0.463
 .MODEL DF D ( IS=27.5p RS=33.8 N=1.10
 + CJO=403p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C3V3;DI_BZT52C3V3;Diodes;Zener <=10V; 3.30V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C3V3  1 2
 *        Terminals    A   K
@@ -1328,6 +1417,8 @@ VZ 2 3 0.827
 .MODEL DF D ( IS=62.4p RS=36.2 N=1.10
 + CJO=403p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=12.5f RS=79.5 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C3V3S;DI_BZT52C3V3S;Diodes;Zener <=10V; 3.30V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1338,9 +1429,10 @@ DZ 3 1 DR
 VZ 2 3 0.756
 .MODEL DF D ( IS=25.0p RS=33.6 N=1.10
 + CJO=403p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C3V6;DI_BZT52C3V6;Diodes;Zener <=10V; 3.60V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C3V6  1 2
 *        Terminals    A   K
@@ -1350,6 +1442,8 @@ VZ 2 3 1.15
 .MODEL DF D ( IS=57.2p RS=35.9 N=1.10
 + CJO=390p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=11.4f RS=74.5 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C3V6S;DI_BZT52C3V6S;Diodes;Zener <=10V; 3.60V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1360,9 +1454,10 @@ DZ 3 1 DR
 VZ 2 3 1.07
 .MODEL DF D ( IS=22.9p RS=33.3 N=1.10
 + CJO=390p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C3V9;DI_BZT52C3V9;Diodes;Zener <=10V; 3.90V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C3V9  1 2
 *        Terminals    A   K
@@ -1372,8 +1467,9 @@ VZ 2 3 1.44
 .MODEL DF D ( IS=52.8p RS=35.7 N=1.10
 + CJO=384p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=10.6f RS=74.5 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-********************************************************************************************************************************
 *SRC=BZT52C3V9S;DI_BZT52C3V9S;Diodes;Zener <=10V; 3.90V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
 .SUBCKT DI_BZT52C3V9S  1 2
@@ -1385,34 +1481,32 @@ VZ 2 3 1.37
 + CJO=384p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=4.23f RS=74.5 N=3.00 )
 .ENDS
-********************************************************************************************************************************
 
-*SRC=BZT52C43;DI_BZT52C43;Diodes;Zener 10V-50V; 43.0V  0.410W   Diodes Inc. Zener 
-*SYM=HZEN 
-.SUBCKT DI_BZT52C43  1 2 
-*        Terminals    A   K 
-D1 1 2 DF 
-DZ 3 1 DR 
-VZ 2 3 40.3 
-.MODEL DF D ( IS=3.93p RS=1.51 N=1.10 
-+ CJO=24.1p VJ=1.00 M=0.330 TT=50.1n ) 
-.MODEL DR D ( IS=7.86e-016 RS=84.5 N=3.00 ) 
+*SRC=BZT52C43;DI_BZT52C43;Diodes;Zener 10V-50V; 43.0V  0.410W   Diodes Inc. Zener
+*SYM=HZEN
+.SUBCKT DI_BZT52C43  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 40.3
+.MODEL DF D ( IS=3.93p RS=1.51 N=1.10
++ CJO=24.1p VJ=1.00 M=0.330 TT=50.1n )
+.MODEL DR D ( IS=7.86e-016 RS=84.5 N=3.00 )
 .ENDS
 
-*SRC=BZT52C47;DI_BZT52C47;Diodes;Zener 10V-50V; 47.0V  0.410W   Diodes Inc. Zener 
-*SYM=HZEN 
-.SUBCKT DI_BZT52C47  1 2 
-*        Terminals    A   K 
-D1 1 2 DF 
-DZ 3 1 DR 
-VZ 2 3 44.3 
-.MODEL DF D ( IS=3.59p RS=1.48 N=1.10 
-+ CJO=24.1p VJ=1.00 M=0.330 TT=50.1n ) 
-.MODEL DR D ( IS=7.19e-016 RS=84.5 N=3.00 ) 
+*SRC=BZT52C47;DI_BZT52C47;Diodes;Zener 10V-50V; 47.0V  0.410W   Diodes Inc. Zener
+*SYM=HZEN
+.SUBCKT DI_BZT52C47  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 44.3
+.MODEL DF D ( IS=3.59p RS=1.48 N=1.10
++ CJO=24.1p VJ=1.00 M=0.330 TT=50.1n )
+.MODEL DR D ( IS=7.19e-016 RS=84.5 N=3.00 )
 .ENDS
 
 *SRC=BZT52C4V3;DI_BZT52C4V3;Diodes;Zener <=10V; 4.30V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C4V3  1 2
 *        Terminals    A   K
@@ -1422,6 +1516,8 @@ VZ 2 3 1.83
 .MODEL DF D ( IS=47.9p RS=35.4 N=1.10
 + CJO=370p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=9.58f RS=74.5 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C4V3S;DI_BZT52C4V3S;Diodes;Zener <=10V; 4.30V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1432,9 +1528,10 @@ DZ 3 1 DR
 VZ 2 3 1.76
 .MODEL DF D ( IS=19.2p RS=32.8 N=1.10
 + CJO=370p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C4V7;DI_BZT52C4V7;Diodes;Zener <=10V; 4.70V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C4V7  1 2
 *        Terminals    A   K
@@ -1444,6 +1541,8 @@ VZ 2 3 2.27
 .MODEL DF D ( IS=43.8p RS=35.2 N=1.10
 + CJO=357p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=8.77f RS=64.5 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C4V7S;DI_BZT52C4V7S;Diodes;Zener <=10V; 4.70V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1454,21 +1553,22 @@ DZ 3 1 DR
 VZ 2 3 2.20
 .MODEL DF D ( IS=17.5p RS=32.6 N=1.10
 + CJO=357p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZT52C51;DI_BZT52C51;Diodes;Zener >50V; 51.0V  0.410W   Diodes Inc. Zener 
-*SYM=HZEN 
-.SUBCKT DI_BZT52C51  1 2 
-*        Terminals    A   K 
-D1 1 2 DF 
-DZ 3 1 DR 
-VZ 2 3 48.3 
-.MODEL DF D ( IS=3.31p RS=1.45 N=1.10 
-+ CJO=24.1p VJ=1.00 M=0.330 TT=50.1n ) 
-.MODEL DR D ( IS=6.62e-016 RS=84.5 N=3.00 ) 
+*SRC=BZT52C51;DI_BZT52C51;Diodes;Zener >50V; 51.0V  0.410W   Diodes Inc. Zener
+*SYM=HZEN
+.SUBCKT DI_BZT52C51  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 48.3
+.MODEL DF D ( IS=3.31p RS=1.45 N=1.10
++ CJO=24.1p VJ=1.00 M=0.330 TT=50.1n )
+.MODEL DR D ( IS=6.62e-016 RS=84.5 N=3.00 )
 .ENDS
 
 *SRC=BZT52C5V1;DI_BZT52C5V1;Diodes;Zener <=10V; 5.10V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C5V1  1 2
 *        Terminals    A   K
@@ -1478,6 +1578,8 @@ VZ 2 3 2.77
 .MODEL DF D ( IS=40.4p RS=34.9 N=1.10
 + CJO=145p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=8.08f RS=44.5 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C5V1S;DI_BZT52C5V1S;Diodes;Zener <=10V; 5.10V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1488,9 +1590,10 @@ DZ 3 1 DR
 VZ 2 3 2.70
 .MODEL DF D ( IS=16.2p RS=32.3 N=1.10
 + CJO=145p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C5V6;DI_BZT52C5V6;Diodes;Zener <=10V; 5.60V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C5V6  1 2
 *        Terminals    A   K
@@ -1500,6 +1603,8 @@ VZ 2 3 3.36
 .MODEL DF D ( IS=36.8p RS=34.7 N=1.10
 + CJO=99.2p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=7.36f RS=24.5 N=3.00
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C5V6S;DI_BZT52C5V6S;Diodes;Zener <=10V; 5.60V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1510,9 +1615,10 @@ DZ 3 1 DR
 VZ 2 3 3.29
 .MODEL DF D ( IS=14.7p RS=32.1 N=1.10
 + CJO=99.2p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C6V2;DI_BZT52C6V2;Diodes;Zener <=10V; 6.20V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C6V2  1 2
 *        Terminals    A   K
@@ -1522,6 +1628,8 @@ VZ 2 3 5.14
 .MODEL DF D ( IS=33.2p RS=34.4 N=1.10
 + CJO=79.4p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=6.65f RS=2.30 N=1.49
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C6V2S;DI_BZT52C6V2S;Diodes;Zener <=10V; 6.20V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1532,9 +1640,10 @@ DZ 3 1 DR
 VZ 2 3 5.10
 .MODEL DF D ( IS=13.3p RS=31.8 N=1.10
 + CJO=79.4p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C6V8;DI_BZT52C6V8;Diodes;Zener <=10V; 6.80V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C6V8  1 2
 *        Terminals    A   K
@@ -1544,6 +1653,8 @@ VZ 2 3 5.20
 .MODEL DF D ( IS=30.3p RS=34.1 N=1.10
 + CJO=72.7p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=6.06f RS=3.45 N=2.23
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C6V8S;DI_BZT52C6V8S;Diodes;Zener <=10V; 6.80V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1554,9 +1665,10 @@ DZ 3 1 DR
 VZ 2 3 5.15
 .MODEL DF D ( IS=12.1p RS=31.5 N=1.10
 + CJO=72.7p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C7V5;DI_BZT52C7V5;Diodes;Zener <=10V; 7.50V  0.500W   Diodes Inc.
--
 *SYM=HZEN
 .SUBCKT DI_BZT52C7V5  1 2
 *        Terminals    A   K
@@ -1566,6 +1678,8 @@ VZ 2 3 5.89
 .MODEL DF D ( IS=27.5p RS=33.8 N=1.10
 + CJO=46.3p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=5.49f RS=3.45 N=2.23
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C7V5S;DI_BZT52C7V5S;Diodes;Zener <=10V; 7.50V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1576,6 +1690,8 @@ DZ 3 1 DR
 VZ 2 3 5.84
 .MODEL DF D ( IS=11.0p RS=31.2 N=1.10
 + CJO=54.2p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C8V2;DI_BZT52C8V2;Diodes;Zener <=10V; 8.20V  0.500W   Diodes Inc. -
 *SYM=HZEN
@@ -1598,6 +1714,8 @@ DZ 3 1 DR
 VZ 2 3 6.53
 .MODEL DF D ( IS=10.0p RS=31.0 N=1.10
 + CJO=51.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZT52C9V1;DI_BZT52C9V1;Diodes;Zener <=10V; 9.10V  0.500W   Diodes Inc. -
 *SYM=HZEN
@@ -1620,8 +1738,10 @@ DZ 3 1 DR
 VZ 2 3 7.43
 .MODEL DF D ( IS=9.05p RS=30.7 N=1.10
 + CJO=48.9p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C10;DI_BZX84C10;Diodes;Zener <=10V; 10.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C10;DI_BZX84C10;Diodes;Zener <=10V; 10.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C10  1 2
 *        Terminals    A   K
@@ -1642,6 +1762,8 @@ DZ 3 1 DR
 VZ 2 3 7.76
 .MODEL DF D ( IS=8.24p RS=30.4 N=1.10
 + CJO=24.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C10T;DI_BZX84C10T;Diodes;Zener <=10V; 10.0V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1652,6 +1774,8 @@ DZ 3 1 DR
 VZ 2 3 7.74
 .MODEL DF D ( IS=6.18p RS=29.6 N=1.10
 + CJO=24.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C10TS;DI_BZX84C10TS;Diodes;Zener <=10V; 10.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -1662,6 +1786,8 @@ DZ 3 1 DR
 VZ 2 3 7.76
 .MODEL DF D ( IS=8.24p RS=30.4 N=1.10
 + CJO=24.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C10W;DI_BZX84C10W;Diodes;Zener <=10V; 10.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1672,8 +1798,10 @@ DZ 3 1 DR
 VZ 2 3 7.76
 .MODEL DF D ( IS=8.24p RS=30.4 N=1.10
 + CJO=24.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C11;DI_BZX84C11;Diodes;Zener 10V-50V; 11.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C11;DI_BZX84C11;Diodes;Zener 10V-50V; 11.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C11  1 2
 *        Terminals    A   K
@@ -1694,6 +1822,8 @@ DZ 3 1 DR
 VZ 2 3 8.76
 .MODEL DF D ( IS=7.49p RS=30.1 N=1.10
 + CJO=45.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C11T;DI_BZX84C11T;Diodes;Zener 10V-50V; 11.0V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1704,6 +1834,8 @@ DZ 3 1 DR
 VZ 2 3 8.74
 .MODEL DF D ( IS=5.62p RS=29.3 N=1.10
 + CJO=45.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C11TS;DI_BZX84C11TS;Diodes;Zener 10V-50V; 11.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -1714,6 +1846,8 @@ DZ 3 1 DR
 VZ 2 3 8.76
 .MODEL DF D ( IS=7.49p RS=30.1 N=1.10
 + CJO=45.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C11W;DI_BZX84C11W;Diodes;Zener 10V-50V; 11.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1724,8 +1858,10 @@ DZ 3 1 DR
 VZ 2 3 8.76
 .MODEL DF D ( IS=7.49p RS=30.1 N=1.10
 + CJO=45.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C12;DI_BZX84C12;Diodes;Zener 10V-50V; 12.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C12;DI_BZX84C12;Diodes;Zener 10V-50V; 12.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C12  1 2
 *        Terminals    A   K
@@ -1746,6 +1882,8 @@ DZ 3 1 DR
 VZ 2 3 9.71
 .MODEL DF D ( IS=6.87p RS=29.9 N=1.10
 + CJO=42.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C12T;DI_BZX84C12T;Diodes;Zener 10V-50V; 12.0V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1756,6 +1894,8 @@ DZ 3 1 DR
 VZ 2 3 9.68
 .MODEL DF D ( IS=5.15p RS=29.1 N=1.10
 + CJO=42.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C12TS;DI_BZX84C12TS;Diodes;Zener 10V-50V; 12.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -1766,6 +1906,8 @@ DZ 3 1 DR
 VZ 2 3 9.71
 .MODEL DF D ( IS=6.87p RS=29.9 N=1.10
 + CJO=42.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C12W;DI_BZX84C12W;Diodes;Zener 10V-50V; 12.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1776,8 +1918,10 @@ DZ 3 1 DR
 VZ 2 3 9.71
 .MODEL DF D ( IS=6.87p RS=29.9 N=1.10
 + CJO=42.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C13;DI_BZX84C13;Diodes;Zener 10V-50V; 13.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C13;DI_BZX84C13;Diodes;Zener 10V-50V; 13.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C13  1 2
 *        Terminals    A   K
@@ -1798,6 +1942,8 @@ DZ 3 1 DR
 VZ 2 3 10.7
 .MODEL DF D ( IS=6.34p RS=29.7 N=1.10
 + CJO=40.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C13T;DI_BZX84C13T;Diodes;Zener 10V-50V; 13.0V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1808,6 +1954,8 @@ DZ 3 1 DR
 VZ 2 3 10.7
 .MODEL DF D ( IS=4.75p RS=28.8 N=1.10
 + CJO=40.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C13TS;DI_BZX84C13TS;Diodes;Zener 10V-50V; 13.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -1818,6 +1966,8 @@ DZ 3 1 DR
 VZ 2 3 10.7
 .MODEL DF D ( IS=6.34p RS=29.7 N=1.10
 + CJO=40.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C13W;DI_BZX84C13W;Diodes;Zener 10V-50V; 13.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1828,8 +1978,10 @@ DZ 3 1 DR
 VZ 2 3 10.7
 .MODEL DF D ( IS=6.34p RS=29.7 N=1.10
 + CJO=40.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C15;DI_BZX84C15;Diodes;Zener 10V-50V; 15.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C15;DI_BZX84C15;Diodes;Zener 10V-50V; 15.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C15  1 2
 *        Terminals    A   K
@@ -1850,6 +2002,8 @@ DZ 3 1 DR
 VZ 2 3 12.7
 .MODEL DF D ( IS=5.49p RS=29.3 N=1.10
 + CJO=37.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C15T;DI_BZX84C15T;Diodes;Zener 10V-50V; 15.0V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1860,6 +2014,8 @@ DZ 3 1 DR
 VZ 2 3 12.6
 .MODEL DF D ( IS=4.12p RS=28.4 N=1.10
 + CJO=37.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C15TS;DI_BZX84C15TS;Diodes;Zener 10V-50V; 15.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -1870,6 +2026,8 @@ DZ 3 1 DR
 VZ 2 3 12.7
 .MODEL DF D ( IS=5.49p RS=29.3 N=1.10
 + CJO=37.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C15W;DI_BZX84C15W;Diodes;Zener 10V-50V; 15.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1880,8 +2038,10 @@ DZ 3 1 DR
 VZ 2 3 12.7
 .MODEL DF D ( IS=5.49p RS=29.3 N=1.10
 + CJO=37.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C16;DI_BZX84C16;Diodes;Zener 10V-50V; 16.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C16;DI_BZX84C16;Diodes;Zener 10V-50V; 16.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C16  1 2
 *        Terminals    A   K
@@ -1902,6 +2062,8 @@ DZ 3 1 DR
 VZ 2 3 13.6
 .MODEL DF D ( IS=5.15p RS=29.1 N=1.10
 + CJO=35.8p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C16T;DI_BZX84C16T;Diodes;Zener 10V-50V; 16.0V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1912,6 +2074,8 @@ DZ 3 1 DR
 VZ 2 3 13.6
 .MODEL DF D ( IS=3.86p RS=28.2 N=1.10
 + CJO=35.8p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C16TS;DI_BZX84C16TS;Diodes;Zener 10V-50V; 16.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -1922,6 +2086,8 @@ DZ 3 1 DR
 VZ 2 3 13.6
 .MODEL DF D ( IS=5.15p RS=29.1 N=1.10
 + CJO=35.8p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C16W;DI_BZX84C16W;Diodes;Zener 10V-50V; 16.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1932,8 +2098,10 @@ DZ 3 1 DR
 VZ 2 3 13.6
 .MODEL DF D ( IS=5.15p RS=29.1 N=1.10
 + CJO=35.8p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C18;DI_BZX84C18;Diodes;Zener 10V-50V; 18.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C18;DI_BZX84C18;Diodes;Zener 10V-50V; 18.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C18  1 2
 *        Terminals    A   K
@@ -1954,6 +2122,8 @@ DZ 3 1 DR
 VZ 2 3 15.6
 .MODEL DF D ( IS=4.58p RS=28.7 N=1.10
 + CJO=33.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C18T;DI_BZX84C18T;Diodes;Zener 10V-50V; 18.0V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1964,6 +2134,8 @@ DZ 3 1 DR
 VZ 2 3 15.6
 .MODEL DF D ( IS=3.43p RS=27.9 N=1.10
 + CJO=33.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C18TS;DI_BZX84C18TS;Diodes;Zener 10V-50V; 18.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -1974,6 +2146,8 @@ DZ 3 1 DR
 VZ 2 3 15.6
 .MODEL DF D ( IS=4.58p RS=28.7 N=1.10
 + CJO=33.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C18W;DI_BZX84C18W;Diodes;Zener 10V-50V; 18.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -1984,8 +2158,10 @@ DZ 3 1 DR
 VZ 2 3 15.6
 .MODEL DF D ( IS=4.58p RS=28.7 N=1.10
 + CJO=33.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C20;DI_BZX84C20;Diodes;Zener 10V-50V; 20.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C20;DI_BZX84C20;Diodes;Zener 10V-50V; 20.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C20  1 2
 *        Terminals    A   K
@@ -2006,6 +2182,8 @@ DZ 3 1 DR
 VZ 2 3 17.5
 .MODEL DF D ( IS=4.12p RS=28.4 N=1.10
 + CJO=31.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C20T;DI_BZX84C20T;Diodes;Zener 10V-50V; 20.0V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2016,6 +2194,8 @@ DZ 3 1 DR
 VZ 2 3 17.5
 .MODEL DF D ( IS=3.09p RS=27.6 N=1.10
 + CJO=31.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C20TS;DI_BZX84C20TS;Diodes;Zener 10V-50V; 20.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2026,6 +2206,8 @@ DZ 3 1 DR
 VZ 2 3 17.5
 .MODEL DF D ( IS=4.12p RS=28.4 N=1.10
 + CJO=31.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C20W;DI_BZX84C20W;Diodes;Zener 10V-50V; 20.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2036,8 +2218,10 @@ DZ 3 1 DR
 VZ 2 3 17.5
 .MODEL DF D ( IS=4.12p RS=28.4 N=1.10
 + CJO=31.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C22;DI_BZX84C22;Diodes;Zener 10V-50V; 22.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C22;DI_BZX84C22;Diodes;Zener 10V-50V; 22.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C22  1 2
 *        Terminals    A   K
@@ -2058,6 +2242,8 @@ DZ 3 1 DR
 VZ 2 3 19.5
 .MODEL DF D ( IS=3.75p RS=28.2 N=1.10
 + CJO=30.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C22T;DI_BZX84C22T;Diodes;Zener 10V-50V; 22.0V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2068,6 +2254,8 @@ DZ 3 1 DR
 VZ 2 3 19.5
 .MODEL DF D ( IS=2.81p RS=27.3 N=1.10
 + CJO=30.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C22TS;DI_BZX84C22TS;Diodes;Zener 10V-50V; 22.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2078,6 +2266,8 @@ DZ 3 1 DR
 VZ 2 3 19.5
 .MODEL DF D ( IS=3.75p RS=28.2 N=1.10
 + CJO=30.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C22W;DI_BZX84C22W;Diodes;Zener 10V-50V; 22.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2088,8 +2278,10 @@ DZ 3 1 DR
 VZ 2 3 19.5
 .MODEL DF D ( IS=3.75p RS=28.2 N=1.10
 + CJO=30.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C24;DI_BZX84C24;Diodes;Zener 10V-50V; 24.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C24;DI_BZX84C24;Diodes;Zener 10V-50V; 24.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C24  1 2
 *        Terminals    A   K
@@ -2110,6 +2302,8 @@ DZ 3 1 DR
 VZ 2 3 21.4
 .MODEL DF D ( IS=3.43p RS=27.9 N=1.10
 + CJO=28.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C24T;DI_BZX84C24T;Diodes;Zener 10V-50V; 24.0V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2120,6 +2314,8 @@ DZ 3 1 DR
 VZ 2 3 21.4
 .MODEL DF D ( IS=2.57p RS=27.1 N=1.10
 + CJO=28.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C24TS;DI_BZX84C24TS;Diodes;Zener 10V-50V; 24.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2130,6 +2326,8 @@ DZ 3 1 DR
 VZ 2 3 21.4
 .MODEL DF D ( IS=3.43p RS=27.9 N=1.10
 + CJO=28.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C24W;DI_BZX84C24W;Diodes;Zener 10V-50V; 24.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2140,8 +2338,10 @@ DZ 3 1 DR
 VZ 2 3 21.4
 .MODEL DF D ( IS=3.43p RS=27.9 N=1.10
 + CJO=28.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C27;DI_BZX84C27;Diodes;Zener 10V-50V; 27.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C27;DI_BZX84C27;Diodes;Zener 10V-50V; 27.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C27  1 2
 *        Terminals    A   K
@@ -2162,6 +2362,8 @@ DZ 3 1 DR
 VZ 2 3 24.7
 .MODEL DF D ( IS=3.05p RS=27.6 N=1.10
 + CJO=27.3p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C27T;DI_BZX84C27T;Diodes;Zener 10V-50V; 27.0V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2172,6 +2374,8 @@ DZ 3 1 DR
 VZ 2 3 24.7
 .MODEL DF D ( IS=2.29p RS=26.8 N=1.10
 + CJO=27.3p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C27TS;DI_BZX84C27TS;Diodes;Zener 10V-50V; 27.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2182,6 +2386,8 @@ DZ 3 1 DR
 VZ 2 3 24.7
 .MODEL DF D ( IS=3.05p RS=27.6 N=1.10
 + CJO=27.3p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C27W;DI_BZX84C27W;Diodes;Zener 10V-50V; 27.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2192,8 +2398,10 @@ DZ 3 1 DR
 VZ 2 3 24.7
 .MODEL DF D ( IS=3.05p RS=27.6 N=1.10
 + CJO=27.3p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C2V4;DI_BZX84C2V4;Diodes;Zener <=10V; 2.40V  0.350W   Diodes Inc. 
+*SRC=BZX84C2V4;DI_BZX84C2V4;Diodes;Zener <=10V; 2.40V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C2V4  1 2
 *        Terminals    A   K
@@ -2214,6 +2422,8 @@ DZ 3 1 DR
 VZ 2 3 0
 .MODEL DF D ( IS=34.3p RS=34.5 N=1.10
 + CJO=205p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C2V4T;DI_BZX84C2V4T;Diodes;Zener <=10V; 2.40V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2224,6 +2434,8 @@ DZ 3 1 DR
 VZ 2 3 0
 .MODEL DF D ( IS=25.7p RS=33.7 N=1.10
 + CJO=205p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C2V4TS;DI_BZX84C2V4TS;Diodes;Zener <=10V; 2.40V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2234,6 +2446,8 @@ DZ 3 1 DR
 VZ 2 3 0
 .MODEL DF D ( IS=34.3p RS=34.5 N=1.10
 + CJO=205p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C2V4W;DI_BZX84C2V4W;Diodes;Zener <=10V; 2.40V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2244,8 +2458,10 @@ DZ 3 1 DR
 VZ 2 3 0
 .MODEL DF D ( IS=34.3p RS=34.5 N=1.10
 + CJO=205p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C2V7;DI_BZX84C2V7;Diodes;Zener <=10V; 2.70V  0.350W   Diodes Inc. 
+*SRC=BZX84C2V7;DI_BZX84C2V7;Diodes;Zener <=10V; 2.70V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C2V7  1 2
 *        Terminals    A   K
@@ -2266,6 +2482,8 @@ DZ 3 1 DR
 VZ 2 3 0.146
 .MODEL DF D ( IS=30.5p RS=34.1 N=1.10
 + CJO=172p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C2V7T;DI_BZX84C2V7T;Diodes;Zener <=10V; 2.70V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2276,6 +2494,8 @@ DZ 3 1 DR
 VZ 2 3 0.124
 .MODEL DF D ( IS=22.9p RS=33.3 N=1.10
 + CJO=172p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C2V7TS;DI_BZX84C2V7TS;Diodes;Zener <=10V; 2.70V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2286,6 +2506,8 @@ DZ 3 1 DR
 VZ 2 3 0.146
 .MODEL DF D ( IS=30.5p RS=34.1 N=1.10
 + CJO=172p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C2V7W;DI_BZX84C2V7W;Diodes;Zener <=10V; 2.70V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2296,8 +2518,10 @@ DZ 3 1 DR
 VZ 2 3 0.146
 .MODEL DF D ( IS=30.5p RS=34.1 N=1.10
 + CJO=172p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C30;DI_BZX84C30;Diodes;Zener 10V-50V; 30.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C30;DI_BZX84C30;Diodes;Zener 10V-50V; 30.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C30  1 2
 *        Terminals    A   K
@@ -2318,6 +2542,8 @@ DZ 3 1 DR
 VZ 2 3 27.7
 .MODEL DF D ( IS=2.75p RS=27.3 N=1.10
 + CJO=26.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C30T;DI_BZX84C30T;Diodes;Zener 10V-50V; 30.0V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2328,6 +2554,8 @@ DZ 3 1 DR
 VZ 2 3 27.6
 .MODEL DF D ( IS=2.06p RS=26.5 N=1.10
 + CJO=26.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C30TS;DI_BZX84C30TS;Diodes;Zener 10V-50V; 30.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2338,6 +2566,8 @@ DZ 3 1 DR
 VZ 2 3 27.7
 .MODEL DF D ( IS=2.75p RS=27.3 N=1.10
 + CJO=26.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C30W;DI_BZX84C30W;Diodes;Zener 10V-50V; 30.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2348,8 +2578,10 @@ DZ 3 1 DR
 VZ 2 3 27.7
 .MODEL DF D ( IS=2.75p RS=27.3 N=1.10
 + CJO=26.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C33;DI_BZX84C33;Diodes;Zener 10V-50V; 33.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C33;DI_BZX84C33;Diodes;Zener 10V-50V; 33.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C33  1 2
 *        Terminals    A   K
@@ -2370,6 +2602,8 @@ DZ 3 1 DR
 VZ 2 3 30.7
 .MODEL DF D ( IS=2.50p RS=27.0 N=1.10
 + CJO=25.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C33T;DI_BZX84C33T;Diodes;Zener 10V-50V; 33.0V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2380,6 +2614,8 @@ DZ 3 1 DR
 VZ 2 3 30.6
 .MODEL DF D ( IS=1.87p RS=26.2 N=1.10
 + CJO=25.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C33TS;DI_BZX84C33TS;Diodes;Zener 10V-50V; 33.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2390,6 +2626,8 @@ DZ 3 1 DR
 VZ 2 3 30.7
 .MODEL DF D ( IS=2.50p RS=27.0 N=1.10
 + CJO=25.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C33W;DI_BZX84C33W;Diodes;Zener 10V-50V; 33.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2400,8 +2638,10 @@ DZ 3 1 DR
 VZ 2 3 30.7
 .MODEL DF D ( IS=2.50p RS=27.0 N=1.10
 + CJO=25.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C36;DI_BZX84C36;Diodes;Zener 10V-50V; 36.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C36;DI_BZX84C36;Diodes;Zener 10V-50V; 36.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C36  1 2
 *        Terminals    A   K
@@ -2422,6 +2662,8 @@ DZ 3 1 DR
 VZ 2 3 33.6
 .MODEL DF D ( IS=2.29p RS=26.8 N=1.10
 + CJO=24.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C36T;DI_BZX84C36T;Diodes;Zener >50V; 536V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2432,6 +2674,8 @@ DZ 3 1 DR
 VZ 2 3 533
 .MODEL DF D ( IS=115f RS=18.2 N=1.10
 + CJO=24.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C36TS;DI_BZX84C36TS;Diodes;Zener 10V-50V; 36.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2442,6 +2686,8 @@ DZ 3 1 DR
 VZ 2 3 33.6
 .MODEL DF D ( IS=2.29p RS=26.8 N=1.10
 + CJO=24.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C36W;DI_BZX84C36W;Diodes;Zener 10V-50V; 36.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2452,8 +2698,10 @@ DZ 3 1 DR
 VZ 2 3 33.6
 .MODEL DF D ( IS=2.29p RS=26.8 N=1.10
 + CJO=24.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C39;DI_BZX84C39;Diodes;Zener 10V-50V; 39.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C39;DI_BZX84C39;Diodes;Zener 10V-50V; 39.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C39  1 2
 *        Terminals    A   K
@@ -2474,6 +2722,8 @@ DZ 3 1 DR
 VZ 2 3 36.5
 .MODEL DF D ( IS=2.11p RS=26.5 N=1.10
 + CJO=23.5p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C39T;DI_BZX84C39T;Diodes;Zener 10V-50V; 39.0V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2484,6 +2734,8 @@ DZ 3 1 DR
 VZ 2 3 36.5
 .MODEL DF D ( IS=1.58p RS=25.7 N=1.10
 + CJO=23.5p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C39TS;DI_BZX84C39TS;Diodes;Zener 10V-50V; 39.0V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2494,6 +2746,8 @@ DZ 3 1 DR
 VZ 2 3 36.5
 .MODEL DF D ( IS=2.11p RS=26.5 N=1.10
 + CJO=23.5p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C39W;DI_BZX84C39W;Diodes;Zener 10V-50V; 39.0V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2504,8 +2758,10 @@ DZ 3 1 DR
 VZ 2 3 36.5
 .MODEL DF D ( IS=2.11p RS=26.5 N=1.10
 + CJO=23.5p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C3V0;DI_BZX84C3V0;Diodes;Zener <=10V; 3.00V  0.350W   Diodes Inc. 
+*SRC=BZX84C3V0;DI_BZX84C3V0;Diodes;Zener <=10V; 3.00V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C3V0  1 2
 *        Terminals    A   K
@@ -2526,6 +2782,8 @@ DZ 3 1 DR
 VZ 2 3 0.463
 .MODEL DF D ( IS=27.5p RS=33.8 N=1.10
 + CJO=147p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C3V0T;DI_BZX84C3V0T;Diodes;Zener <=10V; 3.00V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2536,6 +2794,8 @@ DZ 3 1 DR
 VZ 2 3 0.441
 .MODEL DF D ( IS=20.6p RS=33.0 N=1.10
 + CJO=147p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C3V0TS;DI_BZX84C3V0TS;Diodes;Zener <=10V; 3.00V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2546,6 +2806,8 @@ DZ 3 1 DR
 VZ 2 3 0.463
 .MODEL DF D ( IS=27.5p RS=33.8 N=1.10
 + CJO=147p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C3V0W;DI_BZX84C3V0W;Diodes;Zener <=10V; 3.00V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2556,8 +2818,10 @@ DZ 3 1 DR
 VZ 2 3 0.463
 .MODEL DF D ( IS=27.5p RS=33.8 N=1.10
 + CJO=147p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C3V3;DI_BZX84C3V3;Diodes;Zener <=10V; 3.30V  0.350W   Diodes Inc. 
+*SRC=BZX84C3V3;DI_BZX84C3V3;Diodes;Zener <=10V; 3.30V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C3V3  1 2
 *        Terminals    A   K
@@ -2578,6 +2842,8 @@ DZ 3 1 DR
 VZ 2 3 0.756
 .MODEL DF D ( IS=25.0p RS=33.6 N=1.10
 + CJO=127p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C3V3T;DI_BZX84C3V3T;Diodes;Zener <=10V; 3.30V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2588,6 +2854,8 @@ DZ 3 1 DR
 VZ 2 3 0.733
 .MODEL DF D ( IS=18.7p RS=32.7 N=1.10
 + CJO=127p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C3V3TS;DI_BZX84C3V3TS;Diodes;Zener <=10V; 3.30V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2598,6 +2866,8 @@ DZ 3 1 DR
 VZ 2 3 0.756
 .MODEL DF D ( IS=25.0p RS=33.6 N=1.10
 + CJO=127p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C3V3W;DI_BZX84C3V3W;Diodes;Zener <=10V; 3.30V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2608,8 +2878,10 @@ DZ 3 1 DR
 VZ 2 3 0.756
 .MODEL DF D ( IS=25.0p RS=33.6 N=1.10
 + CJO=127p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C3V6;DI_BZX84C3V6;Diodes;Zener <=10V; 3.60V  0.350W   Diodes Inc. 
+*SRC=BZX84C3V6;DI_BZX84C3V6;Diodes;Zener <=10V; 3.60V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C3V6  1 2
 *        Terminals    A   K
@@ -2630,6 +2902,8 @@ DZ 3 1 DR
 VZ 2 3 1.07
 .MODEL DF D ( IS=22.9p RS=33.3 N=1.10
 + CJO=112p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C3V6T;DI_BZX84C3V6T;Diodes;Zener <=10V; 3.60V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2640,6 +2914,8 @@ DZ 3 1 DR
 VZ 2 3 1.05
 .MODEL DF D ( IS=17.2p RS=32.5 N=1.10
 + CJO=112p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C3V6TS;DI_BZX84C3V6TS;Diodes;Zener <=10V; 3.60V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2650,6 +2926,8 @@ DZ 3 1 DR
 VZ 2 3 1.07
 .MODEL DF D ( IS=22.9p RS=33.3 N=1.10
 + CJO=112p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C3V6W;DI_BZX84C3V6W;Diodes;Zener <=10V; 3.60V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2660,8 +2938,10 @@ DZ 3 1 DR
 VZ 2 3 1.07
 .MODEL DF D ( IS=22.9p RS=33.3 N=1.10
 + CJO=112p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C3V9;DI_BZX84C3V9;Diodes;Zener <=10V; 3.90V  0.350W   Diodes Inc. 
+*SRC=BZX84C3V9;DI_BZX84C3V9;Diodes;Zener <=10V; 3.90V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C3V9  1 2
 *        Terminals    A   K
@@ -2682,6 +2962,8 @@ DZ 3 1 DR
 VZ 2 3 1.37
 .MODEL DF D ( IS=21.1p RS=33.1 N=1.10
 + CJO=94.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C3V9T;DI_BZX84C3V9T;Diodes;Zener <=10V; 3.90V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2692,6 +2974,8 @@ DZ 3 1 DR
 VZ 2 3 1.35
 .MODEL DF D ( IS=15.8p RS=32.3 N=1.10
 + CJO=94.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C3V9TS;DI_BZX84C3V9TS;Diodes;Zener <=10V; 3.90V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2702,6 +2986,8 @@ DZ 3 1 DR
 VZ 2 3 1.37
 .MODEL DF D ( IS=21.1p RS=33.1 N=1.10
 + CJO=94.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C3V9W;DI_BZX84C3V9W;Diodes;Zener <=10V; 3.90V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2712,8 +2998,10 @@ DZ 3 1 DR
 VZ 2 3 1.37
 .MODEL DF D ( IS=21.1p RS=33.1 N=1.10
 + CJO=94.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C43;DI_BZX84C43;Diodes;Zener 10V-50V; 43.0V  0.350W   Diodes Inc. 
+*SRC=BZX84C43;DI_BZX84C43;Diodes;Zener 10V-50V; 43.0V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C43  1 2
 *        Terminals    A   K
@@ -2737,7 +3025,7 @@ VZ 2 3 43.9
 .MODEL DR D ( IS=6.14e-016 RS=154 N=3.00 )
 .ENDS
 
-*SRC=BZX84C4V3;DI_BZX84C4V3;Diodes;Zener <=10V; 4.30V  0.350W   Diodes Inc. 
+*SRC=BZX84C4V3;DI_BZX84C4V3;Diodes;Zener <=10V; 4.30V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C4V3  1 2
 *        Terminals    A   K
@@ -2758,6 +3046,8 @@ DZ 3 1 DR
 VZ 2 3 1.76
 .MODEL DF D ( IS=19.2p RS=32.8 N=1.10
 + CJO=85.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C4V3T;DI_BZX84C4V3T;Diodes;Zener <=10V; 4.30V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2768,6 +3058,8 @@ DZ 3 1 DR
 VZ 2 3 1.74
 .MODEL DF D ( IS=14.4p RS=32.0 N=1.10
 + CJO=85.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C4V3TS;DI_BZX84C4V3TS;Diodes;Zener <=10V; 4.30V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2778,6 +3070,8 @@ DZ 3 1 DR
 VZ 2 3 1.76
 .MODEL DF D ( IS=19.2p RS=32.8 N=1.10
 + CJO=85.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C4V3W;DI_BZX84C4V3W;Diodes;Zener <=10V; 4.30V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2788,8 +3082,10 @@ DZ 3 1 DR
 VZ 2 3 1.76
 .MODEL DF D ( IS=19.2p RS=32.8 N=1.10
 + CJO=85.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C4V7;DI_BZX84C4V7;Diodes;Zener <=10V; 4.70V  0.350W   Diodes Inc. 
+*SRC=BZX84C4V7;DI_BZX84C4V7;Diodes;Zener <=10V; 4.70V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C4V7  1 2
 *        Terminals    A   K
@@ -2810,6 +3106,8 @@ DZ 3 1 DR
 VZ 2 3 2.20
 .MODEL DF D ( IS=17.5p RS=32.6 N=1.10
 + CJO=74.9p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C4V7T;DI_BZX84C4V7T;Diodes;Zener <=10V; 4.70V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2820,6 +3118,8 @@ DZ 3 1 DR
 VZ 2 3 2.18
 .MODEL DF D ( IS=13.1p RS=31.7 N=1.10
 + CJO=74.9p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C4V7TS;DI_BZX84C4V7TS;Diodes;Zener <=10V; 4.70V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2830,6 +3130,8 @@ DZ 3 1 DR
 VZ 2 3 2.20
 .MODEL DF D ( IS=17.5p RS=32.6 N=1.10
 + CJO=74.9p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C4V7W;DI_BZX84C4V7W;Diodes;Zener <=10V; 4.70V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2840,6 +3142,8 @@ DZ 3 1 DR
 VZ 2 3 2.20
 .MODEL DF D ( IS=17.5p RS=32.6 N=1.10
 + CJO=74.9p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=bzx84c51;DI_BZX84C51;Diodes;Zener >50V; 51.0V  0.350W   Diodes Inc. zener
 *SYM=HZEN
@@ -2853,7 +3157,7 @@ VZ 2 3 48.5
 .MODEL DR D ( IS=5.65e-016 RS=141 N=3.00 )
 .ENDS
 
-*SRC=BZX84C5V1;DI_BZX84C5V1;Diodes;Zener <=10V; 5.10V  0.350W   Diodes Inc. 
+*SRC=BZX84C5V1;DI_BZX84C5V1;Diodes;Zener <=10V; 5.10V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C5V1  1 2
 *        Terminals    A   K
@@ -2874,6 +3178,8 @@ DZ 3 1 DR
 VZ 2 3 2.70
 .MODEL DF D ( IS=16.2p RS=32.3 N=1.10
 + CJO=66.2p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C5V1T;DI_BZX84C5V1T;Diodes;Zener <=10V; 5.10V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2884,6 +3190,8 @@ DZ 3 1 DR
 VZ 2 3 2.67
 .MODEL DF D ( IS=12.1p RS=31.5 N=1.10
 + CJO=66.2p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C5V1TS;DI_BZX84C5V1TS;Diodes;Zener <=10V; 5.10V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2894,6 +3202,8 @@ DZ 3 1 DR
 VZ 2 3 2.70
 .MODEL DF D ( IS=16.2p RS=32.3 N=1.10
 + CJO=66.2p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C5V1W;DI_BZX84C5V1W;Diodes;Zener <=10V; 5.10V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2904,8 +3214,10 @@ DZ 3 1 DR
 VZ 2 3 2.70
 .MODEL DF D ( IS=16.2p RS=32.3 N=1.10
 + CJO=66.2p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C5V6;DI_BZX84C5V6;Diodes;Zener <=10V; 5.60V  0.350W   Diodes Inc. 
+*SRC=BZX84C5V6;DI_BZX84C5V6;Diodes;Zener <=10V; 5.60V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C5V6  1 2
 *        Terminals    A   K
@@ -2926,6 +3238,8 @@ DZ 3 1 DR
 VZ 2 3 3.29
 .MODEL DF D ( IS=14.7p RS=32.1 N=1.10
 + CJO=57.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C5V6T;DI_BZX84C5V6T;Diodes;Zener <=10V; 5.60V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2936,6 +3250,8 @@ DZ 3 1 DR
 VZ 2 3 3.27
 .MODEL DF D ( IS=11.0p RS=31.2 N=1.10
 + CJO=57.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C5V6TS;DI_BZX84C5V6TS;Diodes;Zener <=10V; 5.60V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2946,6 +3262,8 @@ DZ 3 1 DR
 VZ 2 3 3.29
 .MODEL DF D ( IS=14.7p RS=32.1 N=1.10
 + CJO=57.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C5V6W;DI_BZX84C5V6W;Diodes;Zener <=10V; 5.60V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2956,8 +3274,10 @@ DZ 3 1 DR
 VZ 2 3 3.29
 .MODEL DF D ( IS=14.7p RS=32.1 N=1.10
 + CJO=57.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C6V2;DI_BZX84C6V2;Diodes;Zener <=10V; 6.20V  0.350W   Diodes Inc. 
+*SRC=BZX84C6V2;DI_BZX84C6V2;Diodes;Zener <=10V; 6.20V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C6V2  1 2
 *        Terminals    A   K
@@ -2978,6 +3298,8 @@ DZ 3 1 DR
 VZ 2 3 5.10
 .MODEL DF D ( IS=13.3p RS=31.8 N=1.10
 + CJO=49.4p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C6V2T;DI_BZX84C6V2T;Diodes;Zener <=10V; 6.20V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -2988,6 +3310,8 @@ DZ 3 1 DR
 VZ 2 3 5.09
 .MODEL DF D ( IS=9.97p RS=31.0 N=1.10
 + CJO=49.4p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C6V2TS;DI_BZX84C6V2TS;Diodes;Zener <=10V; 6.20V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -2998,6 +3322,8 @@ DZ 3 1 DR
 VZ 2 3 5.10
 .MODEL DF D ( IS=13.3p RS=31.8 N=1.10
 + CJO=49.4p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C6V2W;DI_BZX84C6V2W;Diodes;Zener <=10V; 6.20V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -3008,8 +3334,10 @@ DZ 3 1 DR
 VZ 2 3 5.10
 .MODEL DF D ( IS=13.3p RS=31.8 N=1.10
 + CJO=49.4p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C6V8;DI_BZX84C6V8;Diodes;Zener <=10V; 6.80V  0.350W   Diodes Inc. 
+*SRC=BZX84C6V8;DI_BZX84C6V8;Diodes;Zener <=10V; 6.80V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C6V8  1 2
 *        Terminals    A   K
@@ -3030,8 +3358,10 @@ DZ 3 1 DR
 VZ 2 3 5.15
 .MODEL DF D ( IS=12.1p RS=31.5 N=1.10
 + CJO=43.0p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-SRC=BZX84C6V8T;DI_BZX84C6V8T;Diodes;Zener <=10V; 6.80V  0.150W   Diodes Inc. ZENER
+*SRC=BZX84C6V8T;DI_BZX84C6V8T;Diodes;Zener <=10V; 6.80V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
 .SUBCKT DI_BZX84C6V8T  1 2
 *        Terminals    A   K
@@ -3052,6 +3382,8 @@ DZ 3 1 DR
 VZ 2 3 5.15
 .MODEL DF D ( IS=12.1p RS=31.5 N=1.10
 + CJO=43.0p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C6V8W;DI_BZX84C6V8W;Diodes;Zener <=10V; 6.80V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -3062,8 +3394,10 @@ DZ 3 1 DR
 VZ 2 3 5.15
 .MODEL DF D ( IS=12.1p RS=31.5 N=1.10
 + CJO=43.0p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C7V5;DI_C;Diodes;Zener <=10V; 7.50V  0.350W   Diodes Inc. 
+*SRC=BZX84C7V5;DI_C;Diodes;Zener <=10V; 7.50V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C7V5  1 2
 *        Terminals    A   K
@@ -3084,6 +3418,8 @@ DZ 3 1 DR
 VZ 2 3 5.84
 .MODEL DF D ( IS=11.0p RS=31.2 N=1.10
 + CJO=37.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C7V5T;DI_BZX84C7V5T;Diodes;Zener <=10V; 7.50V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -3094,6 +3430,8 @@ DZ 3 1 DR
 VZ 2 3 5.82
 .MODEL DF D ( IS=8.24p RS=30.4 N=1.10
 + CJO=37.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C7V5TS;DI_BZX84C7V5TS;Diodes;Zener <=10V; 7.50V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -3104,6 +3442,8 @@ DZ 3 1 DR
 VZ 2 3 5.84
 .MODEL DF D ( IS=11.0p RS=31.2 N=1.10
 + CJO=37.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C7V5W;DI_BZX84C7V5W;Diodes;Zener <=10V; 7.50V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -3114,8 +3454,10 @@ DZ 3 1 DR
 VZ 2 3 5.84
 .MODEL DF D ( IS=11.0p RS=31.2 N=1.10
 + CJO=37.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C8V2;DI_BZX84C8V2;Diodes;Zener <=10V; 8.20V  0.350W   Diodes Inc. 
+*SRC=BZX84C8V2;DI_BZX84C8V2;Diodes;Zener <=10V; 8.20V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C8V2  1 2
 *        Terminals    A   K
@@ -3136,6 +3478,8 @@ DZ 3 1 DR
 VZ 2 3 6.53
 .MODEL DF D ( IS=10.0p RS=31.0 N=1.10
 + CJO=32.5p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C8V2T;DI_BZX84C8V2T;Diodes;Zener <=10V; 8.20V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -3146,6 +3490,8 @@ DZ 3 1 DR
 VZ 2 3 6.52
 .MODEL DF D ( IS=7.54p RS=30.2 N=1.10
 + CJO=32.5p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C8V2TS;DI_BZX84C8V2TS;Diodes;Zener <=10V; 8.20V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -3156,6 +3502,8 @@ DZ 3 1 DR
 VZ 2 3 6.53
 .MODEL DF D ( IS=10.0p RS=31.0 N=1.10
 + CJO=32.5p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C8V2W;DI_BZX84C8V2W;Diodes;Zener <=10V; 8.20V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -3166,8 +3514,10 @@ DZ 3 1 DR
 VZ 2 3 6.53
 .MODEL DF D ( IS=10.0p RS=31.0 N=1.10
 + CJO=32.5p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=BZX84C9V1;DI_BZX84C9V1;Diodes;Zener <=10V; 9.10V  0.350W   Diodes Inc. 
+*SRC=BZX84C9V1;DI_BZX84C9V1;Diodes;Zener <=10V; 9.10V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_BZX84C9V1  1 2
 *        Terminals    A   K
@@ -3188,6 +3538,8 @@ DZ 3 1 DR
 VZ 2 3 7.43
 .MODEL DF D ( IS=9.05p RS=30.7 N=1.10
 + CJO=27.8p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C9V1T;DI_BZX84C9V1T;Diodes;Zener <=10V; 9.10V  0.150W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -3198,6 +3550,8 @@ DZ 3 1 DR
 VZ 2 3 7.41
 .MODEL DF D ( IS=6.79p RS=29.9 N=1.10
 + CJO=27.8p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C9V1TS;DI_BZX84C9V1TS;Diodes;Zener <=10V; 9.10V  0.200W   Diodes Inc. ZENER Triple, Apply ea. node
 *SYM=HZEN
@@ -3208,6 +3562,8 @@ DZ 3 1 DR
 VZ 2 3 7.43
 .MODEL DF D ( IS=9.05p RS=30.7 N=1.10
 + CJO=27.8p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=BZX84C9V1W;DI_BZX84C9V1W;Diodes;Zener <=10V; 9.10V  0.200W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -3218,6 +3574,8 @@ DZ 3 1 DR
 VZ 2 3 7.43
 .MODEL DF D ( IS=9.05p RS=30.7 N=1.10
 + CJO=27.8p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DDZ10C;DI_DDZ10C;Diodes;Zener <=10V; 10.0V  0.500W   Diodes Inc. ZENER
 *SYM=HZEN
@@ -6132,6 +6490,8 @@ DZ 3 1 DR
 VZ 2 3 8.35
 .MODEL DF D ( IS=12.4p RS=31.6 N=1.10
 + CJO=46.3p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C11;DI_DZ23C11;Diodes;Zener 10V-50V; 11.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6142,6 +6502,8 @@ DZ 3 1 DR
 VZ 2 3 8.79
 .MODEL DF D ( IS=11.2p RS=31.3 N=1.10
 + CJO=41.5p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C12;DI_DZ23C12;Diodes;Zener 10V-50V; 12.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6152,6 +6514,8 @@ DZ 3 1 DR
 VZ 2 3 9.78
 .MODEL DF D ( IS=10.3p RS=31.0 N=1.10
 + CJO=39.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C13;DI_DZ23C13;Diodes;Zener 10V-50V; 13.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6162,6 +6526,8 @@ DZ 3 1 DR
 VZ 2 3 10.7
 .MODEL DF D ( IS=9.51p RS=30.8 N=1.10
 + CJO=37.7p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C15;DI_DZ23C15;Diodes;Zener 10V-50V; 15.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6172,6 +6538,8 @@ DZ 3 1 DR
 VZ 2 3 12.7
 .MODEL DF D ( IS=8.24p RS=30.4 N=1.10
 + CJO=31.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C16;DI_DZ23C16;Diodes;Zener 10V-50V; 16.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6182,6 +6550,8 @@ DZ 3 1 DR
 VZ 2 3 13.6
 .MODEL DF D ( IS=7.72p RS=30.2 N=1.10
 + CJO=30.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C18;DI_DZ23C18;Diodes;Zener 10V-50V; 18.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6192,6 +6562,8 @@ DZ 3 1 DR
 VZ 2 3 15.6
 .MODEL DF D ( IS=6.87p RS=29.9 N=1.10
 + CJO=26.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C20;DI_DZ23C20;Diodes;Zener 10V-50V; 20.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6202,6 +6574,8 @@ DZ 3 1 DR
 VZ 2 3 17.6
 .MODEL DF D ( IS=6.18p RS=29.6 N=1.10
 + CJO=23.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C22;DI_DZ23C22;Diodes;Zener 10V-50V; 22.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6212,6 +6586,8 @@ DZ 3 1 DR
 VZ 2 3 19.5
 .MODEL DF D ( IS=5.62p RS=29.3 N=1.10
 + CJO=22.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C24;DI_DZ23C24;Diodes;Zener 10V-50V; 24.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6222,6 +6598,8 @@ DZ 3 1 DR
 VZ 2 3 21.4
 .MODEL DF D ( IS=5.15p RS=29.1 N=1.10
 + CJO=21.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C27;DI_DZ23C27;Diodes;Zener 10V-50V; 27.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6232,6 +6610,8 @@ DZ 3 1 DR
 VZ 2 3 24.4
 .MODEL DF D ( IS=4.58p RS=28.7 N=1.10
 + CJO=20.7p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C2V7;DI_DZ23C2V7;Diodes;Zener <=10V; 2.70V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6242,6 +6622,8 @@ DZ 3 1 DR
 VZ 2 3 0.263
 .MODEL DF D ( IS=45.8p RS=35.3 N=1.10
 + CJO=450p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C30;DI_DZ23C30;Diodes;Zener 10V-50V; 30.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6252,6 +6634,8 @@ DZ 3 1 DR
 VZ 2 3 27.4
 .MODEL DF D ( IS=4.12p RS=28.4 N=1.10
 + CJO=19.5p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C33;DI_DZ23C33;Diodes;Zener 10V-50V; 33.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6262,6 +6646,8 @@ DZ 3 1 DR
 VZ 2 3 30.4
 .MODEL DF D ( IS=3.75p RS=28.2 N=1.10
 + CJO=18.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C36;DI_DZ23C36;Diodes;Zener 10V-50V; 36.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6272,6 +6658,8 @@ DZ 3 1 DR
 VZ 2 3 33.3
 .MODEL DF D ( IS=3.43p RS=27.9 N=1.10
 + CJO=17.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C39;DI_DZ23C39;Diodes;Zener 10V-50V; 39.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6282,6 +6670,8 @@ DZ 3 1 DR
 VZ 2 3 36.3
 .MODEL DF D ( IS=3.17p RS=27.7 N=1.10
 + CJO=17.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C3V0;DI_DZ23C3V0;Diodes;Zener <=10V; 3.00V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6292,6 +6682,8 @@ DZ 3 1 DR
 VZ 2 3 0.495
 .MODEL DF D ( IS=41.2p RS=35.0 N=1.10
 + CJO=417p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C3V3;DI_DZ23C3V3;Diodes;Zener <=10V; 3.30V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6302,6 +6694,8 @@ DZ 3 1 DR
 VZ 2 3 0.787
 .MODEL DF D ( IS=37.5p RS=34.7 N=1.10
 + CJO=397p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C3V6;DI_DZ23C3V6;Diodes;Zener <=10V; 3.60V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6312,6 +6706,8 @@ DZ 3 1 DR
 VZ 2 3 1.08
 .MODEL DF D ( IS=34.3p RS=34.5 N=1.10
 + CJO=384p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C3V9;DI_DZ23C3V9;Diodes;Zener <=10V; 3.60V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6322,6 +6718,8 @@ DZ 3 1 DR
 VZ 2 3 1.08
 .MODEL DF D ( IS=34.3p RS=34.5 N=1.10
 + CJO=370p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C43;DI_DZ23C43;Diodes;Zener 10V-50V; 43.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6332,6 +6730,8 @@ DZ 3 1 DR
 VZ 2 3 40.3
 .MODEL DF D ( IS=2.87p RS=27.4 N=1.10
 + CJO=16.7p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C47;DI_DZ23C47;Diodes;Zener 10V-50V; 47.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6342,6 +6742,8 @@ DZ 3 1 DR
 VZ 2 3 44.3
 .MODEL DF D ( IS=2.63p RS=27.2 N=1.10
 + CJO=16.3p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C4V3;DI_DZ23C4V3;Diodes;Zener <=10V; 4.30V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6352,6 +6754,8 @@ DZ 3 1 DR
 VZ 2 3 1.77
 .MODEL DF D ( IS=28.7p RS=34.0 N=1.10
 + CJO=357p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C4V7;DI_DZ23C4V7;Diodes;Zener <=10V; 4.70V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6362,6 +6766,8 @@ DZ 3 1 DR
 VZ 2 3 2.24
 .MODEL DF D ( IS=26.3p RS=33.7 N=1.10
 + CJO=350p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C51;DI_DZ23C51;Diodes;Zener >50V; 51.0V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6372,6 +6778,8 @@ DZ 3 1 DR
 VZ 2 3 48.2
 .MODEL DF D ( IS=2.42p RS=26.9 N=1.10
 + CJO=16.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C5V1;DI_DZ23C5V1;Diodes;Zener <=10V; 5.10V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6382,6 +6790,8 @@ DZ 3 1 DR
 VZ 2 3 2.73
 .MODEL DF D ( IS=24.2p RS=33.5 N=1.10
 + CJO=132p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C5V6;DI_DZ23C5V6;Diodes;Zener <=10V; 5.60V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6392,6 +6802,8 @@ DZ 3 1 DR
 VZ 2 3 3.32
 .MODEL DF D ( IS=22.1p RS=33.2 N=1.10
 + CJO=102p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C6V2;DI_DZ23C6V2;Diodes;Zener <=10V; 6.20V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6402,6 +6814,8 @@ DZ 3 1 DR
 VZ 2 3 5.12
 .MODEL DF D ( IS=19.9p RS=32.9 N=1.10
 + CJO=79.4p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C6V8;DI_DZ23C6V8;Diodes;Zener <=10V; 6.80V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6412,6 +6826,8 @@ DZ 3 1 DR
 VZ 2 3 5.93
 .MODEL DF D ( IS=18.2p RS=32.7 N=1.10
 + CJO=72.7p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C7V5;DI_DZ23C7V5;Diodes;Zener <=10V; 7.50V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6422,6 +6838,8 @@ DZ 3 1 DR
 VZ 2 3 6.74
 .MODEL DF D ( IS=16.5p RS=32.4 N=1.10
 + CJO=59.5p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C8V2;DI_DZ23C8V2;Diodes;Zener <=10V; 8.20V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6432,6 +6850,8 @@ DZ 3 1 DR
 VZ 2 3 7.43
 .MODEL DF D ( IS=15.1p RS=32.1 N=1.10
 + CJO=54.2p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=DZ23C9V1;DI_DZ23C9V1;Diodes;Zener <=10V; 9.10V  0.300W   Diodes Inc. Per node.  Device contains two
 *SYM=HZEN
@@ -6442,8 +6862,10 @@ DZ 3 1 DR
 VZ 2 3 8.00
 .MODEL DF D ( IS=13.6p RS=31.8 N=1.10
 + CJO=48.9p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5221B;DI_MMBZ5221B;Diodes;Zener <=10V; 2.40V  0.350W   Diodes Inc. 
+*SRC=MMBZ5221B;DI_MMBZ5221B;Diodes;Zener <=10V; 2.40V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_MMBZ5221B  1 2
 *        Terminals    A   K
@@ -6464,9 +6886,10 @@ DZ 3 1 DR
 VZ 2 3 0
 .MODEL DF D ( IS=34.3p RS=34.5 N=1.10
 + CJO=340p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5221BT;DI_MMBZ5221BT;Diodes;Zener <=10V; 2.40V  0.150W   Diodes
-Inc. -
+*SRC=MMBZ5221BT;DI_MMBZ5221BT;Diodes;Zener <=10V; 2.40V  0.150W   Diodes Inc. -
 *SYM=HZEN
 .SUBCKT DI_MMBZ5221BT  1 2
 *        Terminals    A   K
@@ -6475,28 +6898,34 @@ DZ 3 1 DR
 VZ 2 3 0
 .MODEL DF D ( IS=25.7p RS=33.7 N=1.10
 + CJO=205p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5221BTS;DI_MMBZ5221BTS;Diodes;Zener <=10V; 2.40V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5221BTS  1 2
+*SRC=MMBZ5221BTS;DI_MMBZ5221BTS;Diodes;Zener <=10V; 2.40V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5221BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 0
 .MODEL DF D ( IS=34.3p RS=34.5 N=1.10
 + CJO=340p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5221BW;DI_MMBZ5221BW;Diodes;Zener <=10V; 2.40V  0.200W
-      Diodes Inc.
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5221BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 0
-      .MODEL DF D ( IS=34.3p RS=34.5 N=1.10
-      + CJO=205p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5221BW;DI_MMBZ5221BW;Diodes;Zener <=10V; 2.40V  0.200W   Diodes Inc.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5221BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 0
+.MODEL DF D ( IS=34.3p RS=34.5 N=1.10
++ CJO=205p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5223B;DI_MMBZ5223B;Diodes;Zener <=10V; 2.70V  0.350W   Diodes Inc. 
+*SRC=MMBZ5223B;DI_MMBZ5223B;Diodes;Zener <=10V; 2.70V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_MMBZ5223B  1 2
 *        Terminals    A   K
@@ -6517,9 +6946,10 @@ DZ 3 1 DR
 VZ 2 3 0
 .MODEL DF D ( IS=30.5p RS=34.1 N=1.10
 + CJO=275p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5223BT;DI_MMBZ5223BT;Diodes;Zener <=10V; 2.70V  0.150W   Diodes
-Inc. -
+*SRC=MMBZ5223BT;DI_MMBZ5223BT;Diodes;Zener <=10V; 2.70V  0.150W   Diodes Inc. -
 *SYM=HZEN
 .SUBCKT DI_MMBZ5223BT  1 2
 *        Terminals    A   K
@@ -6528,28 +6958,34 @@ DZ 3 1 DR
 VZ 2 3 0
 .MODEL DF D ( IS=22.9p RS=33.3 N=1.10
 + CJO=172p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5223BTS;DI_MMBZ5223BTS;Diodes;Zener <=10V; 2.70V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5223BTS  1 2
+*SRC=MMBZ5223BTS;DI_MMBZ5223BTS;Diodes;Zener <=10V; 2.70V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5223BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 0
 .MODEL DF D ( IS=30.5p RS=34.1 N=1.10
 + CJO=275p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5223BW;DI_MMBZ5223BW;Diodes;Zener <=10V; 2.70V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5223BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 0
-      .MODEL DF D ( IS=30.5p RS=34.1 N=1.10
-      + CJO=172p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5223BW;DI_MMBZ5223BW;Diodes;Zener <=10V; 2.70V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5223BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 0
+.MODEL DF D ( IS=30.5p RS=34.1 N=1.10
++ CJO=172p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5225B;DI_MMBZ5225B;Diodes;Zener <=10V; 3.00V  0.350W   Diodes Inc. 
+*SRC=MMBZ5225B;DI_MMBZ5225B;Diodes;Zener <=10V; 3.00V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_MMBZ5225B  1 2
 *        Terminals    A   K
@@ -6570,9 +7006,10 @@ DZ 3 1 DR
 VZ 2 3 0.230
 .MODEL DF D ( IS=27.5p RS=33.8 N=1.10
 + CJO=240p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5225BT;DI_MMBZ5225BT;Diodes;Zener <=10V; 3.00V  0.150W   Diodes
-Inc. -
+*SRC=MMBZ5225BT;DI_MMBZ5225BT;Diodes;Zener <=10V; 3.00V  0.150W   Diodes Inc. -
 *SYM=HZEN
 .SUBCKT DI_MMBZ5225BT  1 2
 *        Terminals    A   K
@@ -6581,28 +7018,34 @@ DZ 3 1 DR
 VZ 2 3 0.208
 .MODEL DF D ( IS=20.6p RS=33.0 N=1.10
 + CJO=147p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5225BTS;DI_MMBZ5225BTS;Diodes;Zener <=10V; 3.00V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5225BTS  1 2
+*SRC=MMBZ5225BTS;DI_MMBZ5225BTS;Diodes;Zener <=10V; 3.00V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5225BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 0.230
 .MODEL DF D ( IS=27.5p RS=33.8 N=1.10
 + CJO=240p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5225BW;DI_MMBZ5225BW;Diodes;Zener <=10V; 3.00V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5225BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 0.230
-      .MODEL DF D ( IS=27.5p RS=33.8 N=1.10
-      + CJO=147p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5225BW;DI_MMBZ5225BW;Diodes;Zener <=10V; 3.00V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5225BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 0.230
+.MODEL DF D ( IS=27.5p RS=33.8 N=1.10
++ CJO=147p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5226B;DI_MMBZ5226B;Diodes;Zener <=10V; 3.30V  0.350W   Diodes Inc. 
+*SRC=MMBZ5226B;DI_MMBZ5226B;Diodes;Zener <=10V; 3.30V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_MMBZ5226B  1 2
 *        Terminals    A   K
@@ -6623,9 +7066,10 @@ DZ 3 1 DR
 VZ 2 3 0.563
 .MODEL DF D ( IS=25.0p RS=33.6 N=1.10
 + CJO=230p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5226BT;DI_MMBZ5226BT;Diodes;Zener <=10V; 3.30V  0.150W   Diodes
-Inc. -
+*SRC=MMBZ5226BT;DI_MMBZ5226BT;Diodes;Zener <=10V; 3.30V  0.150W   Diodes Inc. -
 *SYM=HZEN
 .SUBCKT DI_MMBZ5226BT  1 2
 *        Terminals    A   K
@@ -6634,28 +7078,34 @@ DZ 3 1 DR
 VZ 2 3 0.541
 .MODEL DF D ( IS=18.7p RS=32.7 N=1.10
 + CJO=127p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5226BTS;DI_MMBZ5226BTS;Diodes;Zener <=10V; 3.30V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5226BTS  1 2
+*SRC=MMBZ5226BTS;DI_MMBZ5226BTS;Diodes;Zener <=10V; 3.30V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5226BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 0.563
 .MODEL DF D ( IS=25.0p RS=33.6 N=1.10
 + CJO=230p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5226BW;DI_MMBZ5226BW;Diodes;Zener <=10V; 3.30V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5226BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 0.563
-      .MODEL DF D ( IS=25.0p RS=33.6 N=1.10
-      + CJO=127p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5226BW;DI_MMBZ5226BW;Diodes;Zener <=10V; 3.30V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5226BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 0.563
+.MODEL DF D ( IS=25.0p RS=33.6 N=1.10
++ CJO=127p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5227B;DI_MMBZ5227B;Diodes;Zener <=10V; 3.60V  0.350W   Diodes Inc. 
+*SRC=MMBZ5227B;DI_MMBZ5227B;Diodes;Zener <=10V; 3.60V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_MMBZ5227B  1 2
 *        Terminals    A   K
@@ -6676,9 +7126,10 @@ DZ 3 1 DR
 VZ 2 3 0.936
 .MODEL DF D ( IS=22.9p RS=33.3 N=1.10
 + CJO=190p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5227BT;DI_MMBZ5227BT;Diodes;Zener <=10V; 3.60V  0.150W   Diodes
-Inc. -
+*SRC=MMBZ5227BT;DI_MMBZ5227BT;Diodes;Zener <=10V; 3.60V  0.150W   Diodes Inc. -
 *SYM=HZEN
 .SUBCKT DI_MMBZ5227BT  1 2
 *        Terminals    A   K
@@ -6687,28 +7138,34 @@ DZ 3 1 DR
 VZ 2 3 0.914
 .MODEL DF D ( IS=17.2p RS=32.5 N=1.10
 + CJO=112p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5227BTS;DI_MMBZ5227BTS;Diodes;Zener <=10V; 3.60V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5227BTS  1 2
+*SRC=MMBZ5227BTS;DI_MMBZ5227BTS;Diodes;Zener <=10V; 3.60V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5227BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 0.936
 .MODEL DF D ( IS=22.9p RS=33.3 N=1.10
 + CJO=190p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5227BW;DI_MMBZ5227BW;Diodes;Zener <=10V; 3.60V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5227BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 0.936
-      .MODEL DF D ( IS=22.9p RS=33.3 N=1.10
-      + CJO=112p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5227BW;DI_MMBZ5227BW;Diodes;Zener <=10V; 3.60V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5227BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 0.936
+.MODEL DF D ( IS=22.9p RS=33.3 N=1.10
++ CJO=112p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5228B;DI_MMBZ5228B;Diodes;Zener <=10V; 3.90V  0.350W   Diodes Inc. 
+*SRC=MMBZ5228B;DI_MMBZ5228B;Diodes;Zener <=10V; 3.90V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_MMBZ5228B  1 2
 *        Terminals    A   K
@@ -6729,9 +7186,10 @@ DZ 3 1 DR
 VZ 2 3 1.25
 .MODEL DF D ( IS=21.1p RS=33.1 N=1.10
 + CJO=180p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5228BT;DI_MMBZ5228BT;Diodes;Zener <=10V; 3.90V  0.150W   Diodes
-Inc. -
+*SRC=MMBZ5228BT;DI_MMBZ5228BT;Diodes;Zener <=10V; 3.90V  0.150W   Diodes Inc. -
 *SYM=HZEN
 .SUBCKT DI_MMBZ5228BT  1 2
 *        Terminals    A   K
@@ -6740,28 +7198,34 @@ DZ 3 1 DR
 VZ 2 3 1.23
 .MODEL DF D ( IS=15.8p RS=32.3 N=1.10
 + CJO=99.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5228BTS;DI_MMBZ5228BTS;Diodes;Zener <=10V; 3.90V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5228BTS  1 2
+*SRC=MMBZ5228BTS;DI_MMBZ5228BTS;Diodes;Zener <=10V; 3.90V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5228BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 1.25
 .MODEL DF D ( IS=21.1p RS=33.1 N=1.10
 + CJO=180p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5228BW;DI_MMBZ5228BW;Diodes;Zener <=10V; 3.90V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5228BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 1.25
-      .MODEL DF D ( IS=21.1p RS=33.1 N=1.10
-      + CJO=99.1p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5228BW;DI_MMBZ5228BW;Diodes;Zener <=10V; 3.90V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5228BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 1.25
+.MODEL DF D ( IS=21.1p RS=33.1 N=1.10
++ CJO=99.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5229B;DI_MMBZ5229B;Diodes;Zener <=10V; 4.30V  0.350W   Diodes Inc. 
+*SRC=MMBZ5229B;DI_MMBZ5229B;Diodes;Zener <=10V; 4.30V  0.350W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_MMBZ5229B  1 2
 *        Terminals    A   K
@@ -6782,9 +7246,10 @@ DZ 3 1 DR
 VZ 2 3 1.66
 .MODEL DF D ( IS=19.2p RS=32.8 N=1.10
 + CJO=170p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5229BT;DI_MMBZ5229BT;Diodes;Zener <=10V; 4.30V  0.150W   Diodes
-Inc. -
+*SRC=MMBZ5229BT;DI_MMBZ5229BT;Diodes;Zener <=10V; 4.30V  0.150W   Diodes Inc. -
 *SYM=HZEN
 .SUBCKT DI_MMBZ5229BT  1 2
 *        Terminals    A   K
@@ -6793,652 +7258,619 @@ DZ 3 1 DR
 VZ 2 3 1.64
 .MODEL DF D ( IS=14.4p RS=32.0 N=1.10
 + CJO=85.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5229BTS;DI_MMBZ5229BTS;Diodes;Zener <=10V; 4.30V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5229BTS  1 2
+*SRC=MMBZ5229BTS;DI_MMBZ5229BTS;Diodes;Zener <=10V; 4.30V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5229BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 1.66
 .MODEL DF D ( IS=19.2p RS=32.8 N=1.10
 + CJO=170p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5229BW;DI_MMBZ5229BW;Diodes;Zener <=10V; 4.30V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5229BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 1.66
-      .MODEL DF D ( IS=19.2p RS=32.8 N=1.10
-      + CJO=85.6p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5229BW;DI_MMBZ5229BW;Diodes;Zener <=10V; 4.30V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5229BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 1.66
+.MODEL DF D ( IS=19.2p RS=32.8 N=1.10
++ CJO=85.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5230BTS;DI_MMBZ5230BTS;Diodes;Zener <=10V; 4.70V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5230BTS  1 2
+*SRC=MMBZ5230BTS;DI_MMBZ5230BTS;Diodes;Zener <=10V; 4.70V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5230BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 2.12
 .MODEL DF D ( IS=17.5p RS=32.6 N=1.10
 + CJO=160p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5230BW;DI_MMBZ5230BW;Diodes;Zener <=10V; 4.70V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5230BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 2.12
-      .MODEL DF D ( IS=17.5p RS=32.6 N=1.10
-      + CJO=74.9p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5230BW;DI_MMBZ5230BW;Diodes;Zener <=10V; 4.70V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5230BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 2.12
+.MODEL DF D ( IS=17.5p RS=32.6 N=1.10
++ CJO=74.9p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5231BTS;DI_MMBZ5231BTS;Diodes;Zener <=10V; 5.10V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5231BTS  1 2
+*SRC=MMBZ5231BTS;DI_MMBZ5231BTS;Diodes;Zener <=10V; 5.10V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5231BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 2.55
 .MODEL DF D ( IS=16.2p RS=32.3 N=1.10
 + CJO=145p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5231BW;DI_MMBZ5231BW;Diodes;Zener <=10V; 5.10V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5231BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 2.55
-      .MODEL DF D ( IS=16.2p RS=32.3 N=1.10
-      + CJO=66.2p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5231BW;DI_MMBZ5231BW;Diodes;Zener <=10V; 5.10V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5231BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 2.55
+.MODEL DF D ( IS=16.2p RS=32.3 N=1.10
++ CJO=66.2p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5232BTS;DI_MMBZ5232BTS;Diodes;Zener <=10V; 5.60V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5232BTS  1 2
+*SRC=MMBZ5232BTS;DI_MMBZ5232BTS;Diodes;Zener <=10V; 5.60V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5232BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 3.16
 .MODEL DF D ( IS=14.7p RS=32.1 N=1.10
 + CJO=130p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5232BW;DI_MMBZ5232BW;Diodes;Zener <=10V; 5.60V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5232BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 3.16
-      .MODEL DF D ( IS=14.7p RS=32.1 N=1.10
-      + CJO=57.6p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5232BW;DI_MMBZ5232BW;Diodes;Zener <=10V; 5.60V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5232BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 3.16
+.MODEL DF D ( IS=14.7p RS=32.1 N=1.10
++ CJO=57.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-*SRC=MMBZ5233BTS;DI_MMBZ5233BTS;Diodes;Zener <=10V; 6.00V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5233BTS  1 2
+*SRC=MMBZ5233BTS;DI_MMBZ5233BTS;Diodes;Zener <=10V; 6.00V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5233BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 3.64
 .MODEL DF D ( IS=13.7p RS=31.9 N=1.10
 + CJO=125p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5234BTS;DI_MMBZ5234BTS;Diodes;Zener <=10V; 6.20V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5234BTS  1 2
+*SRC=MMBZ5234BTS;DI_MMBZ5234BTS;Diodes;Zener <=10V; 6.20V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5234BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 3.83
 .MODEL DF D ( IS=13.3p RS=31.8 N=1.10
 + CJO=120p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5234BW;DI_MMBZ5234BW;Diodes;Zener <=10V; 6.20V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5234BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 3.83
-      .MODEL DF D ( IS=13.3p RS=31.8 N=1.10
-      + CJO=49.4p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5234BW;DI_MMBZ5234BW;Diodes;Zener <=10V; 6.20V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5234BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 3.83
+.MODEL DF D ( IS=13.3p RS=31.8 N=1.10
++ CJO=49.4p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5235BTS;DI_MMBZ5235BTS;Diodes;Zener <=10V; 6.80V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5235BTS  1 2
+*SRC=MMBZ5235BTS;DI_MMBZ5235BTS;Diodes;Zener <=10V; 6.80V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5235BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 4.49
 .MODEL DF D ( IS=12.1p RS=31.5 N=1.10
 + CJO=110p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5235BW;DI_MMBZ5235BW;Diodes;Zener <=10V; 6.80V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5235BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 4.49
-      .MODEL DF D ( IS=12.1p RS=31.5 N=1.10
-      + CJO=43.0p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5235BW;DI_MMBZ5235BW;Diodes;Zener <=10V; 6.80V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5235BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 4.49
+.MODEL DF D ( IS=12.1p RS=31.5 N=1.10
++ CJO=43.0p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5236BTS;DI_MMBZ5236BTS;Diodes;Zener <=10V; 7.50V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5236BTS  1 2
+*SRC=MMBZ5236BTS;DI_MMBZ5236BTS;Diodes;Zener <=10V; 7.50V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5236BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 5.14
 .MODEL DF D ( IS=11.0p RS=31.2 N=1.10
 + CJO=95.0p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5236BW;DI_MMBZ5236BW;Diodes;Zener <=10V; 7.50V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5236BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 5.14
-      .MODEL DF D ( IS=11.0p RS=31.2 N=1.10
-      + CJO=37.1p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5236BW;DI_MMBZ5236BW;Diodes;Zener <=10V; 7.50V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5236BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 5.14
+.MODEL DF D ( IS=11.0p RS=31.2 N=1.10
++ CJO=37.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5237BTS;DI_MMBZ5237BTS;Diodes;Zener <=10V; 8.20V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5237BTS  1 2
+*SRC=MMBZ5237BTS;DI_MMBZ5237BTS;Diodes;Zener <=10V; 8.20V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5237BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 5.79
 .MODEL DF D ( IS=10.0p RS=31.0 N=1.10
 + CJO=88.0p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5237BW;DI_MMBZ5237BW;Diodes;Zener <=10V; 8.20V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5237BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 5.79
-      .MODEL DF D ( IS=10.0p RS=31.0 N=1.10
-      + CJO=32.5p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5237BW;DI_MMBZ5237BW;Diodes;Zener <=10V; 8.20V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5237BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 5.79
+.MODEL DF D ( IS=10.0p RS=31.0 N=1.10
++ CJO=32.5p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-*SRC=MMBZ5238BTS;DI_MMBZ5238BTS;Diodes;Zener <=10V; 8.70V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5238BTS  1 2
+*SRC=MMBZ5238BTS;DI_MMBZ5238BTS;Diodes;Zener <=10V; 8.70V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5238BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 6.29
 .MODEL DF D ( IS=9.47p RS=30.8 N=1.10
 + CJO=83.0p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5239BTS;DI_MMBZ5239BTS;Diodes;Zener <=10V; 9.10V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5239BTS  1 2
+*SRC=MMBZ5239BTS;DI_MMBZ5239BTS;Diodes;Zener <=10V; 9.10V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5239BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 6.64
 .MODEL DF D ( IS=9.05p RS=30.7 N=1.10
 + CJO=80.0p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5239BW;DI_MMBZ5239BW;Diodes;Zener <=10V; 9.10V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5239BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 6.64
-      .MODEL DF D ( IS=9.05p RS=30.7 N=1.10
-      + CJO=27.8p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5239BW;DI_MMBZ5239BW;Diodes;Zener <=10V; 9.10V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5239BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 6.64
+.MODEL DF D ( IS=9.05p RS=30.7 N=1.10
++ CJO=27.8p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5240BTS;DI_MMBZ5240BTS;Diodes;Zener <=10V; 10.0V  0.200W   Diodes
-Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5240BTS  1 2
+*SRC=MMBZ5240BTS;DI_MMBZ5240BTS;Diodes;Zener <=10V; 10.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5240BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 7.40
 .MODEL DF D ( IS=8.24p RS=30.4 N=1.10
 + CJO=77.0p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5240BW;DI_MMBZ5240BW;Diodes;Zener <=10V; 10.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5240BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 7.40
-      .MODEL DF D ( IS=8.24p RS=30.4 N=1.10
-      + CJO=24.1p VJ=0.750 M=0.330 TT=50.1n )
+*SRC=MMBZ5240BW;DI_MMBZ5240BW;Diodes;Zener <=10V; 10.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5240BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 7.40
+.MODEL DF D ( IS=8.24p RS=30.4 N=1.10
++ CJO=24.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5241BTS;DI_MMBZ5241BTS;Diodes;Zener 10V-50V; 11.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5241BTS  1 2
+*SRC=MMBZ5241BTS;DI_MMBZ5241BTS;Diodes;Zener 10V-50V; 11.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5241BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 8.29
 .MODEL DF D ( IS=7.49p RS=30.1 N=1.10
 + CJO=75.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5241BW;DI_MMBZ5241BW;Diodes;Zener 10V-50V; 11.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5241BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 8.29
-      .MODEL DF D ( IS=7.49p RS=30.1 N=1.10
-      + CJO=45.2p VJ=1.00 M=0.330 TT=50.1n )
+*SRC=MMBZ5241BW;DI_MMBZ5241BW;Diodes;Zener 10V-50V; 11.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5241BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 8.29
+.MODEL DF D ( IS=7.49p RS=30.1 N=1.10
++ CJO=45.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5242BTS;DI_MMBZ5242BTS;Diodes;Zener 10V-50V; 12.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5242BTS  1 2
+*SRC=MMBZ5242BTS;DI_MMBZ5242BTS;Diodes;Zener 10V-50V; 12.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5242BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 9.12
 .MODEL DF D ( IS=6.87p RS=29.9 N=1.10
 + CJO=74.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5242BW;DI_MMBZ5242BW;Diodes;Zener 10V-50V; 12.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5242BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 9.12
-      .MODEL DF D ( IS=6.87p RS=29.9 N=1.10
-      + CJO=42.7p VJ=1.00 M=0.330 TT=50.1n )
+*SRC=MMBZ5242BW;DI_MMBZ5242BW;Diodes;Zener 10V-50V; 12.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5242BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 9.12
+.MODEL DF D ( IS=6.87p RS=29.9 N=1.10
++ CJO=42.7p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5243BTS;DI_MMBZ5243BTS;Diodes;Zener 10V-50V; 13.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5243BTS  1 2
+*SRC=MMBZ5243BTS;DI_MMBZ5243BTS;Diodes;Zener 10V-50V; 13.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5243BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 10.7
 .MODEL DF D ( IS=6.34p RS=29.7 N=1.10
 + CJO=66.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5243BW;DI_MMBZ5243BW;Diodes;Zener 10V-50V; 13.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5243BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 10.7
-      .MODEL DF D ( IS=6.34p RS=29.7 N=1.10
-      + CJO=40.6p VJ=1.00 M=0.330 TT=50.1n )
+*SRC=MMBZ5243BW;DI_MMBZ5243BW;Diodes;Zener 10V-50V; 13.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5243BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 10.7
+.MODEL DF D ( IS=6.34p RS=29.7 N=1.10
++ CJO=40.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5245BTS;DI_MMBZ5245BTS;Diodes;Zener 10V-50V; 15.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5245BTS  1 2
+*SRC=MMBZ5245BTS;DI_MMBZ5245BTS;Diodes;Zener 10V-50V; 15.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5245BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 12.6
 .MODEL DF D ( IS=5.49p RS=29.3 N=1.10
 + CJO=60.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5245BW;DI_MMBZ5245BW;Diodes;Zener 10V-50V; 15.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5245BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 12.6
-      .MODEL DF D ( IS=5.49p RS=29.3 N=1.10
-      + CJO=37.2p VJ=1.00 M=0.330 TT=50.1n )
+*SRC=MMBZ5245BW;DI_MMBZ5245BW;Diodes;Zener 10V-50V; 15.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5245BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 12.6
+.MODEL DF D ( IS=5.49p RS=29.3 N=1.10
++ CJO=37.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5246BTS;DI_MMBZ5246BTS;Diodes;Zener 10V-50V; 16.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5246BTS  1 2
+*SRC=MMBZ5246BTS;DI_MMBZ5246BTS;Diodes;Zener 10V-50V; 16.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5246BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 13.6
 .MODEL DF D ( IS=5.15p RS=29.1 N=1.10
 + CJO=58.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5246BW;DI_MMBZ5246BW;Diodes;Zener 10V-50V; 16.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5246BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 13.6
-      .MODEL DF D ( IS=5.15p RS=29.1 N=1.10
-      + CJO=35.8p VJ=1.00 M=0.330 TT=50.1n )
+*SRC=MMBZ5246BW;DI_MMBZ5246BW;Diodes;Zener 10V-50V; 16.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5246BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 13.6
+.MODEL DF D ( IS=5.15p RS=29.1 N=1.10
++ CJO=35.8p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5248BTS;DI_MMBZ5248BTS;Diodes;Zener 10V-50V; 18.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5248BTS  1 2
+*SRC=MMBZ5248BTS;DI_MMBZ5248BTS;Diodes;Zener 10V-50V; 18.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5248BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 15.6
 .MODEL DF D ( IS=4.58p RS=28.7 N=1.10
 + CJO=53.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5248BW;DI_MMBZ5248BW;Diodes;Zener 10V-50V; 18.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5248BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 15.6
-      .MODEL DF D ( IS=4.58p RS=28.7 N=1.10
-      + CJO=33.5p VJ=1.00 M=0.330 TT=50.1n )
+*SRC=MMBZ5248BW;DI_MMBZ5248BW;Diodes;Zener 10V-50V; 18.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5248BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 15.6
+.MODEL DF D ( IS=4.58p RS=28.7 N=1.10
++ CJO=33.5p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5250BTS;DI_MMBZ5250BTS;Diodes;Zener 10V-50V; 20.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5250BTS  1 2
+*SRC=MMBZ5250BTS;DI_MMBZ5250BTS;Diodes;Zener 10V-50V; 20.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5250BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 17.6
 .MODEL DF D ( IS=4.12p RS=28.4 N=1.10
 + CJO=50.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5250BW;DI_MMBZ5250BW;Diodes;Zener 10V-50V; 20.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5250BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 17.6
-      .MODEL DF D ( IS=4.12p RS=28.4 N=1.10
-      + CJO=31.6p VJ=1.00 M=0.330 TT=50.1n )
+*SRC=MMBZ5250BW;DI_MMBZ5250BW;Diodes;Zener 10V-50V; 20.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5250BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 17.6
+.MODEL DF D ( IS=4.12p RS=28.4 N=1.10
++ CJO=31.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5251BTS;DI_MMBZ5251BTS;Diodes;Zener 10V-50V; 22.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5251BTS  1 2
+*SRC=MMBZ5251BTS;DI_MMBZ5251BTS;Diodes;Zener 10V-50V; 22.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5251BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 19.6
 .MODEL DF D ( IS=3.75p RS=28.2 N=1.10
 + CJO=48.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5251BW;DI_MMBZ5251BW;Diodes;Zener 10V-50V; 22.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5251BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 19.6
-      .MODEL DF D ( IS=3.75p RS=28.2 N=1.10
-      + CJO=30.1p VJ=1.00 M=0.330 TT=50.1n )
+*SRC=MMBZ5251BW;DI_MMBZ5251BW;Diodes;Zener 10V-50V; 22.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5251BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 19.6
+.MODEL DF D ( IS=3.75p RS=28.2 N=1.10
++ CJO=30.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5252BTS;DI_MMBZ5252BTS;Diodes;Zener 10V-50V; 24.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5252BTS  1 2
+*SRC=MMBZ5252BTS;DI_MMBZ5252BTS;Diodes;Zener 10V-50V; 24.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5252BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 21.6
 .MODEL DF D ( IS=3.43p RS=27.9 N=1.10
 + CJO=45.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5252BW;DI_MMBZ5252BW;Diodes;Zener 10V-50V; 24.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5252BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 21.6
-      .MODEL DF D ( IS=3.43p RS=27.9 N=1.10
-      + CJO=28.9p VJ=1.00 M=0.330 TT=50.1n )
+*SRC=MMBZ5252BW;DI_MMBZ5252BW;Diodes;Zener 10V-50V; 24.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5252BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 21.6
+.MODEL DF D ( IS=3.43p RS=27.9 N=1.10
++ CJO=28.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5254BTS;DI_MMBZ5254BTS;Diodes;Zener 10V-50V; 27.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5254BTS  1 2
+*SRC=MMBZ5254BTS;DI_MMBZ5254BTS;Diodes;Zener 10V-50V; 27.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5254BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 24.6
 .MODEL DF D ( IS=3.05p RS=27.6 N=1.10
 + CJO=42.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5254BW;DI_MMBZ5254BW;Diodes;Zener 10V-50V; 27.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5254BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 24.6
-      .MODEL DF D ( IS=3.05p RS=27.6 N=1.10
-      + CJO=27.3p VJ=1.00 M=0.330 TT=50.1n )
+*SRC=MMBZ5254BW;DI_MMBZ5254BW;Diodes;Zener 10V-50V; 27.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5254BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 24.6
+.MODEL DF D ( IS=3.05p RS=27.6 N=1.10
++ CJO=27.3p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5255BTS;DI_MMBZ5255BTS;Diodes;Zener 10V-50V; 28.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5255BTS  1 2
+*SRC=MMBZ5255BTS;DI_MMBZ5255BTS;Diodes;Zener 10V-50V; 28.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5255BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 25.6
 .MODEL DF D ( IS=2.94p RS=27.5 N=1.10
 + CJO=41.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-
-
-*SRC=MMBZ5256BTS;DI_MMBZ5256BTS;Diodes;Zener 10V-50V; 30.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5256BTS  1 2
+*SRC=MMBZ5256BTS;DI_MMBZ5256BTS;Diodes;Zener 10V-50V; 30.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5256BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 27.6
 .MODEL DF D ( IS=2.75p RS=27.3 N=1.10
 + CJO=40.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5256BW;DI_MMBZ5256BW;Diodes;Zener 10V-50V; 30.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5256BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 27.6
-      .MODEL DF D ( IS=2.75p RS=27.3 N=1.10
-      + CJO=26.1p VJ=1.00 M=0.330 TT=50.1n )
+*SRC=MMBZ5256BW;DI_MMBZ5256BW;Diodes;Zener 10V-50V; 30.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5256BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 27.6
+.MODEL DF D ( IS=2.75p RS=27.3 N=1.10
++ CJO=26.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5257BTS;DI_MMBZ5257BTS;Diodes;Zener 10V-50V; 33.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5257BTS  1 2
+*SRC=MMBZ5257BTS;DI_MMBZ5257BTS;Diodes;Zener 10V-50V; 33.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5257BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 30.6
 .MODEL DF D ( IS=2.50p RS=27.0 N=1.10
 + CJO=39.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5257BW;DI_MMBZ5257BW;Diodes;Zener 10V-50V; 33.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5257BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 30.6
-      .MODEL DF D ( IS=2.50p RS=27.0 N=1.10
-      + CJO=25.1p VJ=1.00 M=0.330 TT=50.1n )
+*SRC=MMBZ5257BW;DI_MMBZ5257BW;Diodes;Zener 10V-50V; 33.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5257BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 30.6
+.MODEL DF D ( IS=2.50p RS=27.0 N=1.10
++ CJO=25.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5258BTS;DI_MMBZ5258BTS;Diodes;Zener 10V-50V; 36.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5258BTS  1 2
+*SRC=MMBZ5258BTS;DI_MMBZ5258BTS;Diodes;Zener 10V-50V; 36.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg.
+*SYM=HZEN
+.SUBCKT DI_MMBZ5258BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 33.5
 .MODEL DF D ( IS=2.29p RS=26.8 N=1.10
 + CJO=38.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5258BW;DI_MMBZ5258BW;Diodes;Zener 10V-50V; 36.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5258BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 33.5
-      .MODEL DF D ( IS=2.29p RS=26.8 N=1.10
-      + CJO=24.2p VJ=1.00 M=0.330 TT=50.1n )
+*SRC=MMBZ5258BW;DI_MMBZ5258BW;Diodes;Zener 10V-50V; 36.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5258BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 33.5
+.MODEL DF D ( IS=2.29p RS=26.8 N=1.10
++ CJO=24.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-
-
-
-
-
-
-*SRC=MMBZ5259BTS;DI_MMBZ5259BTS;Diodes;Zener 10V-50V; 39.0V  0.200W Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN .SUBCKT DI_MMBZ5259BTS  1 2
+*SRC=MMBZ5259BTS;DI_MMBZ5259BTS;Diodes;Zener 10V-50V; 39.0V  0.200W   Diodes Inc. This model covers only one element.  There are three elements per pkg. *SYM=HZEN
+.SUBCKT DI_MMBZ5259BTS  1 2
 *        Terminals    A   K
 D1 1 2 DF
 DZ 3 1 DR
 VZ 2 3 36.5
 .MODEL DF D ( IS=2.11p RS=26.5 N=1.10
 + CJO=37.0p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
-*SRC=MMBZ5259BW;DI_MMBZ5259BW;Diodes;Zener 10V-50V; 39.0V  0.200W
-      Diodes Inc. -
-      *SYM=HZEN
-      .SUBCKT DI_MMBZ5259BW  1 2
-      *        Terminals    A   K
-      D1 1 2 DF
-      DZ 3 1 DR
-      VZ 2 3 36.5
-      .MODEL DF D ( IS=2.11p RS=26.5 N=1.10
-      + CJO=23.3p VJ=1.00 M=0.330 TT=50.1n )
+*SRC=MMBZ5259BW;DI_MMBZ5259BW;Diodes;Zener 10V-50V; 39.0V  0.200W   Diodes Inc. -
+*SYM=HZEN
+.SUBCKT DI_MMBZ5259BW  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 36.5
+.MODEL DF D ( IS=2.11p RS=26.5 N=1.10
++ CJO=23.3p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5221B;DI_MMSZ5221B;Diodes;Zener <=10V; 2.40V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7449,6 +7881,8 @@ DZ 3 1 DR
 VZ 2 3 0
 .MODEL DF D ( IS=85.8p RS=37.1 N=1.10
 + CJO=794p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5221BS;DI_MMSZ5221BS;Diodes;Zener <=10V; 2.40V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7459,6 +7893,8 @@ DZ 3 1 DR
 VZ 2 3 0
 .MODEL DF D ( IS=85.8p RS=37.1 N=1.10
 + CJO=794p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5223B;DI_MMSZ5223B;Diodes;Zener <=10V; 2.70V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7469,6 +7905,8 @@ DZ 3 1 DR
 VZ 2 3 9.75m
 .MODEL DF D ( IS=76.3p RS=36.7 N=1.10
 + CJO=463p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5223BS;DI_MMSZ5223BS;Diodes;Zener <=10V; 2.70V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7479,6 +7917,8 @@ DZ 3 1 DR
 VZ 2 3 9.75m
 .MODEL DF D ( IS=76.3p RS=36.7 N=1.10
 + CJO=463p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5225B;DI_MMSZ5225B;Diodes;Zener <=10V; 3.00V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7489,6 +7929,8 @@ DZ 3 1 DR
 VZ 2 3 0.302
 .MODEL DF D ( IS=68.7p RS=36.4 N=1.10
 + CJO=397p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5225BS;DI_MMSZ5225BS;Diodes;Zener <=10V; 3.00V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7499,6 +7941,8 @@ DZ 3 1 DR
 VZ 2 3 0.302
 .MODEL DF D ( IS=68.7p RS=36.4 N=1.10
 + CJO=397p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5226B;DI_MMSZ5226B;Diodes;Zener <=10V; 3.30V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7509,6 +7953,8 @@ DZ 3 1 DR
 VZ 2 3 0.634
 .MODEL DF D ( IS=62.4p RS=36.2 N=1.10
 + CJO=251p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5226BS;DI_MMSZ5226BS;Diodes;Zener <=10V; 3.30V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7519,6 +7965,8 @@ DZ 3 1 DR
 VZ 2 3 0.634
 .MODEL DF D ( IS=62.4p RS=36.2 N=1.10
 + CJO=251p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5227B;DI_MMSZ5227B;Diodes;Zener <=10V; 3.60V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7529,6 +7977,8 @@ DZ 3 1 DR
 VZ 2 3 1.01
 .MODEL DF D ( IS=57.2p RS=35.9 N=1.10
 + CJO=238p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5227BS;DI_MMSZ5227BS;Diodes;Zener <=10V; 3.60V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7539,6 +7989,8 @@ DZ 3 1 DR
 VZ 2 3 1.01
 .MODEL DF D ( IS=57.2p RS=35.9 N=1.10
 + CJO=238p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5228B;DI_MMSZ5228B;Diodes;Zener <=10V; 3.90V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7549,6 +8001,8 @@ DZ 3 1 DR
 VZ 2 3 1.32
 .MODEL DF D ( IS=52.8p RS=35.7 N=1.10
 + CJO=159p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5228BS;DI_MMSZ5228BS;Diodes;Zener <=10V; 3.90V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7559,6 +8013,8 @@ DZ 3 1 DR
 VZ 2 3 1.32
 .MODEL DF D ( IS=52.8p RS=35.7 N=1.10
 + CJO=159p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5229B;DI_MMSZ5229B;Diodes;Zener <=10V; 4.30V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7569,6 +8025,8 @@ DZ 3 1 DR
 VZ 2 3 1.73
 .MODEL DF D ( IS=47.9p RS=35.4 N=1.10
 + CJO=145p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5229BS;DI_MMSZ5229BS;Diodes;Zener <=10V; 4.30V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7579,6 +8037,8 @@ DZ 3 1 DR
 VZ 2 3 1.73
 .MODEL DF D ( IS=47.9p RS=35.4 N=1.10
 + CJO=145p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5230B;DI_MMSZ5230B;Diodes;Zener <=10V; 4.70V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7589,6 +8049,8 @@ DZ 3 1 DR
 VZ 2 3 2.19
 .MODEL DF D ( IS=43.8p RS=35.2 N=1.10
 + CJO=139p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5230BS;DI_MMSZ5230BS;Diodes;Zener <=10V; 4.70V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7599,6 +8061,8 @@ DZ 3 1 DR
 VZ 2 3 2.19
 .MODEL DF D ( IS=43.8p RS=35.2 N=1.10
 + CJO=139p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5231B;DI_MMSZ5231B;Diodes;Zener <=10V; 5.10V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7609,6 +8073,8 @@ DZ 3 1 DR
 VZ 2 3 2.62
 .MODEL DF D ( IS=40.4p RS=34.9 N=1.10
 + CJO=132p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5231BS;DI_MMSZ5231BS;Diodes;Zener <=10V; 5.10V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7619,6 +8085,8 @@ DZ 3 1 DR
 VZ 2 3 2.62
 .MODEL DF D ( IS=40.4p RS=34.9 N=1.10
 + CJO=132p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5232B;DI_MMSZ5232B;Diodes;Zener <=10V; 5.60V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7629,6 +8097,8 @@ DZ 3 1 DR
 VZ 2 3 3.23
 .MODEL DF D ( IS=36.8p RS=34.7 N=1.10
 + CJO=106p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5232BS;DI_MMSZ5232BS;Diodes;Zener <=10V; 5.60V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7639,6 +8109,8 @@ DZ 3 1 DR
 VZ 2 3 3.23
 .MODEL DF D ( IS=36.8p RS=34.7 N=1.10
 + CJO=106p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5233B;DI_MMSZ5233B;Diodes;Zener <=10V; 6.00V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7649,6 +8121,8 @@ DZ 3 1 DR
 VZ 2 3 3.71
 .MODEL DF D ( IS=34.3p RS=34.5 N=1.10
 + CJO=83.3p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5233BS;DI_MMSZ5233BS;Diodes;Zener <=10V; 6.00V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7659,6 +8133,8 @@ DZ 3 1 DR
 VZ 2 3 3.71
 .MODEL DF D ( IS=34.3p RS=34.5 N=1.10
 + CJO=83.3p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5234B;DI_MMSZ5234B;Diodes;Zener <=10V; 6.20V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7669,6 +8145,8 @@ DZ 3 1 DR
 VZ 2 3 3.91
 .MODEL DF D ( IS=33.2p RS=34.4 N=1.10
 + CJO=79.4p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5234BS;DI_MMSZ5234BS;Diodes;Zener <=10V; 6.20V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7679,6 +8157,8 @@ DZ 3 1 DR
 VZ 2 3 3.91
 .MODEL DF D ( IS=33.2p RS=34.4 N=1.10
 + CJO=79.4p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5235B;DI_MMSZ5235B;Diodes;Zener <=10V; 6.80V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7689,6 +8169,8 @@ DZ 3 1 DR
 VZ 2 3 4.56
 .MODEL DF D ( IS=30.3p RS=34.1 N=1.10
 + CJO=71.4p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5235BS;DI_MMSZ5235BS;Diodes;Zener <=10V; 6.80V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7699,6 +8181,8 @@ DZ 3 1 DR
 VZ 2 3 4.56
 .MODEL DF D ( IS=30.3p RS=34.1 N=1.10
 + CJO=71.4p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5236B;DI_MMSZ5236B;Diodes;Zener <=10V; 7.50V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7709,6 +8193,8 @@ DZ 3 1 DR
 VZ 2 3 5.21
 .MODEL DF D ( IS=27.5p RS=33.8 N=1.10
 + CJO=58.2p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5236BS;DI_MMSZ5236BS;Diodes;Zener <=10V; 7.50V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7719,6 +8205,8 @@ DZ 3 1 DR
 VZ 2 3 5.21
 .MODEL DF D ( IS=27.5p RS=33.8 N=1.10
 + CJO=58.2p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5237B;DI_MMSZ5237B;Diodes;Zener <=10V; 8.20V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7729,6 +8217,8 @@ DZ 3 1 DR
 VZ 2 3 5.86
 .MODEL DF D ( IS=25.1p RS=33.6 N=1.10
 + CJO=52.9p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5237BS;DI_MMSZ5237BS;Diodes;Zener <=10V; 8.20V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7739,6 +8229,8 @@ DZ 3 1 DR
 VZ 2 3 5.86
 .MODEL DF D ( IS=25.1p RS=33.6 N=1.10
 + CJO=52.9p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5238B;DI_MMSZ5238B;Diodes;Zener <=10V; 8.70V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7749,6 +8241,8 @@ DZ 3 1 DR
 VZ 2 3 6.36
 .MODEL DF D ( IS=23.7p RS=33.4 N=1.10
 + CJO=51.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5238BS;DI_MMSZ5238BS;Diodes;Zener <=10V; 8.70V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7759,6 +8253,8 @@ DZ 3 1 DR
 VZ 2 3 6.36
 .MODEL DF D ( IS=23.7p RS=33.4 N=1.10
 + CJO=51.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5239B;DI_MMSZ5239B;Diodes;Zener <=10V; 9.10V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7769,6 +8265,8 @@ DZ 3 1 DR
 VZ 2 3 6.72
 .MODEL DF D ( IS=22.6p RS=33.3 N=1.10
 + CJO=50.3p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5239BS;DI_MMSZ5239BS;Diodes;Zener <=10V; 9.10V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7779,6 +8277,8 @@ DZ 3 1 DR
 VZ 2 3 6.72
 .MODEL DF D ( IS=22.6p RS=33.3 N=1.10
 + CJO=50.3p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5240B;DI_MMSZ5240B;Diodes;Zener <=10V; 10.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7789,6 +8289,8 @@ DZ 3 1 DR
 VZ 2 3 7.47
 .MODEL DF D ( IS=20.6p RS=33.0 N=1.10
 + CJO=46.3p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5240BS;DI_MMSZ5240BS;Diodes;Zener <=10V; 10.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7799,6 +8301,8 @@ DZ 3 1 DR
 VZ 2 3 7.47
 .MODEL DF D ( IS=20.6p RS=33.0 N=1.10
 + CJO=46.3p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5241B;DI_MMSZ5241B;Diodes;Zener 10V-50V; 11.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7809,6 +8313,8 @@ DZ 3 1 DR
 VZ 2 3 8.36
 .MODEL DF D ( IS=18.7p RS=32.7 N=1.10
 + CJO=32.7p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5241BS;DI_MMSZ5241BS;Diodes;Zener 10V-50V; 11.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7819,6 +8325,8 @@ DZ 3 1 DR
 VZ 2 3 8.36
 .MODEL DF D ( IS=18.7p RS=32.7 N=1.10
 + CJO=32.7p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5242B;DI_MMSZ5242B;Diodes;Zener 10V-50V; 12.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7829,6 +8337,8 @@ DZ 3 1 DR
 VZ 2 3 9.19
 .MODEL DF D ( IS=17.2p RS=32.5 N=1.10
 + CJO=31.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5242BS;DI_MMSZ5242BS;Diodes;Zener 10V-50V; 12.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7839,6 +8349,8 @@ DZ 3 1 DR
 VZ 2 3 9.19
 .MODEL DF D ( IS=17.2p RS=32.5 N=1.10
 + CJO=31.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5243B;DI_MMSZ5243B;Diodes;Zener 10V-50V; 13.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7849,6 +8361,8 @@ DZ 3 1 DR
 VZ 2 3 10.7
 .MODEL DF D ( IS=15.8p RS=32.3 N=1.10
 + CJO=30.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5243BS;DI_MMSZ5243BS;Diodes;Zener 10V-50V; 13.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7859,6 +8373,8 @@ DZ 3 1 DR
 VZ 2 3 10.7
 .MODEL DF D ( IS=15.8p RS=32.3 N=1.10
 + CJO=30.2p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5245B;DI_MMSZ5245B;Diodes;Zener 10V-50V; 15.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7869,6 +8385,8 @@ DZ 3 1 DR
 VZ 2 3 12.7
 .MODEL DF D ( IS=13.7p RS=31.9 N=1.10
 + CJO=28.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5245BS;DI_MMSZ5245BS;Diodes;Zener 10V-50V; 15.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7879,6 +8397,8 @@ DZ 3 1 DR
 VZ 2 3 12.7
 .MODEL DF D ( IS=13.7p RS=31.9 N=1.10
 + CJO=28.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5246B;DI_MMSZ5246B;Diodes;Zener 10V-50V; 16.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7889,6 +8409,8 @@ DZ 3 1 DR
 VZ 2 3 13.7
 .MODEL DF D ( IS=12.9p RS=31.7 N=1.10
 + CJO=27.7p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5246BS;DI_MMSZ5246BS;Diodes;Zener 10V-50V; 16.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7899,6 +8421,8 @@ DZ 3 1 DR
 VZ 2 3 13.7
 .MODEL DF D ( IS=12.9p RS=31.7 N=1.10
 + CJO=27.7p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5248B;DI_MMSZ5248B;Diodes;Zener 10V-50V; 18.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7909,6 +8433,8 @@ DZ 3 1 DR
 VZ 2 3 15.7
 .MODEL DF D ( IS=11.4p RS=31.3 N=1.10
 + CJO=25.8p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5248BS;DI_MMSZ5248BS;Diodes;Zener 10V-50V; 18.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7919,6 +8445,8 @@ DZ 3 1 DR
 VZ 2 3 15.7
 .MODEL DF D ( IS=11.4p RS=31.3 N=1.10
 + CJO=25.8p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5250B;DI_MMSZ5250B;Diodes;Zener 10V-50V; 20.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7929,6 +8457,8 @@ DZ 3 1 DR
 VZ 2 3 17.7
 .MODEL DF D ( IS=10.3p RS=31.0 N=1.10
 + CJO=25.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5250BS;DI_MMSZ5250BS;Diodes;Zener 10V-50V; 20.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7939,6 +8469,8 @@ DZ 3 1 DR
 VZ 2 3 17.7
 .MODEL DF D ( IS=10.3p RS=31.0 N=1.10
 + CJO=25.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5251B;DI_MMSZ5251B;Diodes;Zener 10V-50V; 22.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7949,6 +8481,8 @@ DZ 3 1 DR
 VZ 2 3 19.7
 .MODEL DF D ( IS=9.36p RS=30.8 N=1.10
 + CJO=18.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5251BS;DI_MMSZ5251BS;Diodes;Zener 10V-50V; 22.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7959,6 +8493,8 @@ DZ 3 1 DR
 VZ 2 3 19.7
 .MODEL DF D ( IS=9.36p RS=30.8 N=1.10
 + CJO=18.9p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5252B;DI_MMSZ5252B;Diodes;Zener 10V-50V; 24.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7969,6 +8505,8 @@ DZ 3 1 DR
 VZ 2 3 21.7
 .MODEL DF D ( IS=8.58p RS=30.5 N=1.10
 + CJO=17.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5252BS;DI_MMSZ5252BS;Diodes;Zener 10V-50V; 24.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7979,6 +8517,8 @@ DZ 3 1 DR
 VZ 2 3 21.7
 .MODEL DF D ( IS=8.58p RS=30.5 N=1.10
 + CJO=17.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5254B;DI_MMSZ5254B;Diodes;Zener 10V-50V; 27.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7989,6 +8529,8 @@ DZ 3 1 DR
 VZ 2 3 24.6
 .MODEL DF D ( IS=7.63p RS=30.2 N=1.10
 + CJO=16.3p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5254BS;DI_MMSZ5254BS;Diodes;Zener 10V-50V; 27.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -7999,6 +8541,8 @@ DZ 3 1 DR
 VZ 2 3 24.6
 .MODEL DF D ( IS=7.63p RS=30.2 N=1.10
 + CJO=16.3p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5255B;DI_MMSZ5255B;Diodes;Zener 10V-50V; 28.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -8009,6 +8553,8 @@ DZ 3 1 DR
 VZ 2 3 25.6
 .MODEL DF D ( IS=7.36p RS=30.1 N=1.10
 + CJO=15.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5255BS;DI_MMSZ5255BS;Diodes;Zener 10V-50V; 28.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -8019,6 +8565,8 @@ DZ 3 1 DR
 VZ 2 3 25.6
 .MODEL DF D ( IS=7.36p RS=30.1 N=1.10
 + CJO=15.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5256B;DI_MMSZ5256B;Diodes;Zener 10V-50V; 30.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -8029,6 +8577,8 @@ DZ 3 1 DR
 VZ 2 3 27.6
 .MODEL DF D ( IS=6.87p RS=29.9 N=1.10
 + CJO=14.5p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5256BS;DI_MMSZ5256BS;Diodes;Zener 10V-50V; 30.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -8039,6 +8589,8 @@ DZ 3 1 DR
 VZ 2 3 27.6
 .MODEL DF D ( IS=6.87p RS=29.9 N=1.10
 + CJO=14.5p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5257B;DI_MMSZ5257B;Diodes;Zener 10V-50V; 33.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -8049,6 +8601,8 @@ DZ 3 1 DR
 VZ 2 3 30.6
 .MODEL DF D ( IS=6.24p RS=29.6 N=1.10
 + CJO=14.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5257BS;DI_MMSZ5257BS;Diodes;Zener 10V-50V; 33.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -8059,6 +8613,8 @@ DZ 3 1 DR
 VZ 2 3 30.6
 .MODEL DF D ( IS=6.24p RS=29.6 N=1.10
 + CJO=14.1p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5258B;DI_MMSZ5258B;Diodes;Zener 10V-50V; 36.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -8069,6 +8625,8 @@ DZ 3 1 DR
 VZ 2 3 33.6
 .MODEL DF D ( IS=5.72p RS=29.4 N=1.10
 + CJO=13.8p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5258BS;DI_MMSZ5258BS;Diodes;Zener 10V-50V; 36.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -8079,6 +8637,8 @@ DZ 3 1 DR
 VZ 2 3 33.6
 .MODEL DF D ( IS=5.72p RS=29.4 N=1.10
 + CJO=13.8p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5259B;DI_MMSZ5259B;Diodes;Zener 10V-50V; 39.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -8089,6 +8649,8 @@ DZ 3 1 DR
 VZ 2 3 36.6
 .MODEL DF D ( IS=5.28p RS=29.1 N=1.10
 + CJO=13.7p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=MMSZ5259BS;DI_MMSZ5259BS;Diodes;Zener 10V-50V; 39.0V  0.500W   Diodes Inc. 500 mW Zener
 *SYM=HZEN
@@ -8099,6 +8661,8 @@ DZ 3 1 DR
 VZ 2 3 36.6
 .MODEL DF D ( IS=5.28p RS=29.1 N=1.10
 + CJO=13.7p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=PZX363C3V9;DI_PZX363C3V9;Diodes;Zener <=10V; 3.90V  0.200W   Diodes Inc. Five Element Zener Diode Array - One element of array
 *SYM=HZEN
@@ -8110,6 +8674,8 @@ VZ 2 3 1.37
 .MODEL DF D ( IS=21.1p RS=33.1 N=1.10
 + CJO=397p VJ=0.750 M=0.330 TT=50.1n )
 .MODEL DR D ( IS=4.23f RS=74.5 N=3.00 )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=QZX363C12;DI_QZX363C12;Diodes;Zener 10V-50V; 12.0V  0.200W   Diodes Inc. Zener Diode Array, quad, one node of four
 *SYM=HZEN
@@ -8120,6 +8686,8 @@ DZ 3 1 DR
 VZ 2 3 9.71
 .MODEL DF D ( IS=6.87p RS=29.9 N=1.10
 + CJO=26.4p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=QZX363C15;DI_QZX363C15;Diodes;Zener 10V-50V; 15.0V  0.200W   Diodes Inc. Zener Diode Array, quad, one node of four
 *SYM=HZEN
@@ -8130,6 +8698,8 @@ DZ 3 1 DR
 VZ 2 3 12.7
 .MODEL DF D ( IS=5.49p RS=29.3 N=1.10
 + CJO=25.8p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=QZX363C20;DI_QZX363C20;Diodes;Zener 10V-50V; 20.0V  0.200W   Diodes Inc. Zener Diode Array, quad, one node of four
 *SYM=HZEN
@@ -8140,6 +8710,8 @@ DZ 3 1 DR
 VZ 2 3 17.5
 .MODEL DF D ( IS=4.12p RS=28.4 N=1.10
 + CJO=22.6p VJ=1.00 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=QZX363C5V6;DI_QZX363C5V6;Diodes;Zener <=10V; 5.60V  0.200W   Diodes Inc. Zener Diode Array, quad, one node of four
 *SYM=HZEN
@@ -8150,6 +8722,8 @@ DZ 3 1 DR
 VZ 2 3 3.29
 .MODEL DF D ( IS=14.7p RS=32.1 N=1.10
 + CJO=92.6p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=QZX363C6V8;DI_QZX363C6V8;Diodes;Zener <=10V; 6.80V  0.200W   Diodes Inc. Zener Diode Array, quad, one node of four
 *SYM=HZEN
@@ -8160,6 +8734,8 @@ DZ 3 1 DR
 VZ 2 3 5.15
 .MODEL DF D ( IS=12.1p RS=31.5 N=1.10
 + CJO=66.1p VJ=0.750 M=0.330 TT=50.1n )
+.ENDS
+* !!! Manually added ENDS. Probably corrupt model.
 
 *SRC=SMAZ10;DI_SMAZ10;Diodes;Zener <=10V; 10.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
@@ -8173,8 +8749,7 @@ VZ 2 3 9.20
 .MODEL DR D ( IS=8.24f RS=0.161 N=1.04 )
 .ENDS
 
-*SRC=SMAZ12;DI_SMAZ12;Diodes;Zener 10V-50V; 12.0V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ12;DI_SMAZ12;Diodes;Zener 10V-50V; 12.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ12  1 2
 *        Terminals    A   K
@@ -8186,8 +8761,7 @@ VZ 2 3 10.8
 .MODEL DR D ( IS=6.87f RS=0.230 N=1.49 )
 .ENDS
 
-*SRC=SMAZ15;DI_SMAZ15;Diodes;Zener 10V-50V; 15.0V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ15;DI_SMAZ15;Diodes;Zener 10V-50V; 15.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ15  1 2
 *        Terminals    A   K
@@ -8199,8 +8773,7 @@ VZ 2 3 13.8
 .MODEL DR D ( IS=5.49f RS=0.230 N=1.49 )
 .ENDS
 
-*SRC=SMAZ16;DI_SMAZ16;Diodes;Zener 10V-50V; 16.0V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ16;DI_SMAZ16;Diodes;Zener 10V-50V; 16.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ16  1 2
 *        Terminals    A   K
@@ -8212,8 +8785,7 @@ VZ 2 3 14.9
 .MODEL DR D ( IS=5.15f RS=0.460 N=1.49 )
 .ENDS
 
-*SRC=SMAZ18;DI_SMAZ18;Diodes;Zener 10V-50V; 18.0V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ18;DI_SMAZ18;Diodes;Zener 10V-50V; 18.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ18  1 2
 *        Terminals    A   K
@@ -8225,8 +8797,7 @@ VZ 2 3 16.6
 .MODEL DR D ( IS=4.58f RS=0.575 N=1.86 )
 .ENDS
 
-*SRC=SMAZ20;DI_SMAZ20;Diodes;Zener 10V-50V; 20.0V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ20;DI_SMAZ20;Diodes;Zener 10V-50V; 20.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ20  1 2
 *        Terminals    A   K
@@ -8238,8 +8809,7 @@ VZ 2 3 18.3
 .MODEL DR D ( IS=4.12f RS=0.690 N=2.23 )
 .ENDS
 
-*SRC=SMAZ22;DI_SMAZ22;Diodes;Zener 10V-50V; 22.0V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ22;DI_SMAZ22;Diodes;Zener 10V-50V; 22.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ22  1 2
 *        Terminals    A   K
@@ -8251,8 +8821,7 @@ VZ 2 3 20.2
 .MODEL DR D ( IS=3.75f RS=0.736 N=2.38 )
 .ENDS
 
-*SRC=SMAZ24;DI_SMAZ24;Diodes;Zener 10V-50V; 24.0V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ24;DI_SMAZ24;Diodes;Zener 10V-50V; 24.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ24  1 2
 *        Terminals    A   K
@@ -8264,8 +8833,7 @@ VZ 2 3 21.7
 .MODEL DR D ( IS=3.43f RS=0.920 N=2.97 )
 .ENDS
 
-*SRC=SMAZ27;DI_SMAZ27;Diodes;Zener 10V-50V; 27.0V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ27;DI_SMAZ27;Diodes;Zener 10V-50V; 27.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ27  1 2
 *        Terminals    A   K
@@ -8277,8 +8845,7 @@ VZ 2 3 25.0
 .MODEL DR D ( IS=3.05f RS=0.805 N=2.60 )
 .ENDS
 
-*SRC=SMAZ30;DI_SMAZ30;Diodes;Zener 10V-50V; 30.0V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ30;DI_SMAZ30;Diodes;Zener 10V-50V; 30.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ30  1 2
 *        Terminals    A   K
@@ -8290,8 +8857,7 @@ VZ 2 3 27.6
 .MODEL DR D ( IS=2.75f RS=2.39 N=3.00 )
 .ENDS
 
-*SRC=SMAZ33;DI_SMAZ33;Diodes;Zener 10V-50V; 33.0V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ33;DI_SMAZ33;Diodes;Zener 10V-50V; 33.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ33  1 2
 *        Terminals    A   K
@@ -8303,8 +8869,7 @@ VZ 2 3 30.6
 .MODEL DR D ( IS=2.50f RS=2.89 N=3.00 )
 .ENDS
 
-*SRC=SMAZ36;DI_SMAZ36;Diodes;Zener 10V-50V; 36.0V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ36;DI_SMAZ36;Diodes;Zener 10V-50V; 36.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ36  1 2
 *        Terminals    A   K
@@ -8316,8 +8881,7 @@ VZ 2 3 34.4
 .MODEL DR D ( IS=2.29f RS=1.61 N=2.08 )
 .ENDS
 
-*SRC=SMAZ39;DI_SMAZ39;Diodes;Zener 10V-50V; 39.0V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ39;DI_SMAZ39;Diodes;Zener 10V-50V; 39.0V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ39  1 2
 *        Terminals    A   K
@@ -8329,8 +8893,7 @@ VZ 2 3 37.2
 .MODEL DR D ( IS=2.11f RS=1.84 N=2.38 )
 .ENDS
 
-*SRC=SMAZ5V1;DI_SMAZ5V1;Diodes;Zener <=10V; 5.10V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ5V1;DI_SMAZ5V1;Diodes;Zener <=10V; 5.10V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ5V1  1 2
 *        Terminals    A   K
@@ -8342,8 +8905,7 @@ VZ 2 3 4.41
 .MODEL DR D ( IS=16.2f RS=69.0m N=0.892 )
 .ENDS
 
-*SRC=SMAZ6V2;DI_SMAZ6V2;Diodes;Zener <=10V; 6.20V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ6V2;DI_SMAZ6V2;Diodes;Zener <=10V; 6.20V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ6V2  1 2
 *        Terminals    A   K
@@ -8355,21 +8917,7 @@ VZ 2 3 5.28
 .MODEL DR D ( IS=13.3f RS=92.0m N=1.19 )
 .ENDS
 
-*SRC=SMAZ6V2;DI_SMAZ6V2;Diodes;Zener <=10V; 6.20V  1.00W   Diodes Inc.
-Zener
-*SYM=HZEN
-.SUBCKT DI_SMAZ6V2  1 2
-*        Terminals    A   K
-D1 1 2 DF
-DZ 3 1 DR
-VZ 2 3 5.28
-.MODEL DF D ( IS=66.5p RS=0.891 N=1.10
-+ CJO=1.06n VJ=0.750 M=0.330 TT=50.1n )
-.MODEL DR D ( IS=13.3f RS=92.0m N=1.19 )
-.ENDS
-
-*SRC=SMAZ6V8;DI_SMAZ6V8;Diodes;Zener <=10V; 6.80V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ6V8;DI_SMAZ6V8;Diodes;Zener <=10V; 6.80V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ6V8  1 2
 *        Terminals    A   K
@@ -8381,8 +8929,7 @@ VZ 2 3 5.87
 .MODEL DR D ( IS=12.1f RS=92.0m N=1.19 )
 .ENDS
 
-*SRC=SMAZ7V5;DI_SMAZ7V5;Diodes;Zener <=10V; 7.50V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ7V5;DI_SMAZ7V5;Diodes;Zener <=10V; 7.50V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ7V5  1 2
 *        Terminals    A   K
@@ -8394,8 +8941,7 @@ VZ 2 3 6.55
 .MODEL DR D ( IS=11.0f RS=94.3m N=1.22 )
 .ENDS
 
-*SRC=SMAZ8V2;DI_SMAZ8V2;Diodes;Zener <=10V; 8.20V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ8V2;DI_SMAZ8V2;Diodes;Zener <=10V; 8.20V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ8V2  1 2
 *        Terminals    A   K
@@ -8407,8 +8953,7 @@ VZ 2 3 7.04
 .MODEL DR D ( IS=10.0f RS=0.115 N=1.49 )
 .ENDS
 
-*SRC=SMAZ9V1;DI_SMAZ9V1;Diodes;Zener <=10V; 9.10V  1.00W   Diodes Inc.
-Zener
+*SRC=SMAZ9V1;DI_SMAZ9V1;Diodes;Zener <=10V; 9.10V  1.00W   Diodes Inc. Zener
 *SYM=HZEN
 .SUBCKT DI_SMAZ9V1  1 2
 *        Terminals    A   K
@@ -8420,7 +8965,7 @@ VZ 2 3 8.30
 .MODEL DR D ( IS=9.05f RS=0.161 N=1.04 )
 .ENDS
 
-*SRC=ZM4728A;DI_ZM4728A;Diodes;Zener <=10V; 3.30V  1.00W   Diodes Inc. 
+*SRC=ZM4728A;DI_ZM4728A;Diodes;Zener <=10V; 3.30V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4728A  1 2
 *        Terminals    A   K
@@ -8432,7 +8977,7 @@ VZ 2 3 0.384
 .MODEL DR D ( IS=25.0f RS=8.98 N=3.00 )
 .ENDS
 
-*SRC=ZM4729A;DI_ZM4729A;Diodes;Zener <=10V; 3.60V  1.00W   Diodes Inc. 
+*SRC=ZM4729A;DI_ZM4729A;Diodes;Zener <=10V; 3.60V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4729A  1 2
 *        Terminals    A   K
@@ -8444,7 +8989,7 @@ VZ 2 3 0.755
 .MODEL DR D ( IS=22.9f RS=8.87 N=3.00 )
 .ENDS
 
-*SRC=ZM4730A;DI_ZM4730A;Diodes;Zener <=10V; 3.90V  1.00W   Diodes Inc. 
+*SRC=ZM4730A;DI_ZM4730A;Diodes;Zener <=10V; 3.90V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4730A  1 2
 *        Terminals    A   K
@@ -8456,7 +9001,7 @@ VZ 2 3 1.17
 .MODEL DR D ( IS=21.1f RS=7.79 N=3.00 )
 .ENDS
 
-*SRC=ZM4731A;DI_ZM4731A;Diodes;Zener <=10V; 4.30V  1.00W   Diodes Inc. 
+*SRC=ZM4731A;DI_ZM4731A;Diodes;Zener <=10V; 4.30V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4731A  1 2
 *        Terminals    A   K
@@ -8468,7 +9013,7 @@ VZ 2 3 1.68
 .MODEL DR D ( IS=19.2f RS=6.66 N=3.00 )
 .ENDS
 
-*SRC=ZM4732A;DI_ZM4732A;Diodes;Zener <=10V; 4.70V  1.00W   Diodes Inc. 
+*SRC=ZM4732A;DI_ZM4732A;Diodes;Zener <=10V; 4.70V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4732A  1 2
 *        Terminals    A   K
@@ -8480,7 +9025,7 @@ VZ 2 3 2.12
 .MODEL DR D ( IS=17.5f RS=6.53 N=3.00 )
 .ENDS
 
-*SRC=ZM4733A;DI_ZM4733A;Diodes;Zener <=10V; 5.10V  1.00W   Diodes Inc. 
+*SRC=ZM4733A;DI_ZM4733A;Diodes;Zener <=10V; 5.10V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4733A  1 2
 *        Terminals    A   K
@@ -8492,7 +9037,7 @@ VZ 2 3 2.60
 .MODEL DR D ( IS=16.2f RS=5.41 N=3.00 )
 .ENDS
 
-*SRC=ZM4734A;DI_ZM4734A;Diodes;Zener <=10V; 5.60V  1.00W   Diodes Inc. 
+*SRC=ZM4734A;DI_ZM4734A;Diodes;Zener <=10V; 5.60V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4734A  1 2
 *        Terminals    A   K
@@ -8504,7 +9049,7 @@ VZ 2 3 3.22
 .MODEL DR D ( IS=14.7f RS=3.27 N=3.00 )
 .ENDS
 
-*SRC=ZM4735A;DI_ZM4735A;Diodes;Zener <=10V; 6.20V  1.00W   Diodes Inc. 
+*SRC=ZM4735A;DI_ZM4735A;Diodes;Zener <=10V; 6.20V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4735A  1 2
 *        Terminals    A   K
@@ -8516,7 +9061,7 @@ VZ 2 3 4.37
 .MODEL DR D ( IS=13.3f RS=0.460 N=2.44 )
 .ENDS
 
-*SRC=ZM4736A;DI_ZM4736A;Diodes;Zener <=10V; 6.80V  1.00W   Diodes Inc. 
+*SRC=ZM4736A;DI_ZM4736A;Diodes;Zener <=10V; 6.80V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4736A  1 2
 *        Terminals    A   K
@@ -8528,7 +9073,7 @@ VZ 2 3 4.51
 .MODEL DR D ( IS=12.1f RS=1.40 N=3.00 )
 .ENDS
 
-*SRC=ZM4737A;DI_ZM4737A;Diodes;Zener <=10V; 7.50V  1.00W   Diodes Inc. 
+*SRC=ZM4737A;DI_ZM4737A;Diodes;Zener <=10V; 7.50V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4737A  1 2
 *        Terminals    A   K
@@ -8540,7 +9085,7 @@ VZ 2 3 5.21
 .MODEL DR D ( IS=11.0f RS=1.71 N=3.00 )
 .ENDS
 
-*SRC=ZM4738A;DI_ZM4738A;Diodes;Zener <=10V; 8.20V  1.00W   Diodes Inc. 
+*SRC=ZM4738A;DI_ZM4738A;Diodes;Zener <=10V; 8.20V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4738A  1 2
 *        Terminals    A   K
@@ -8552,7 +9097,7 @@ VZ 2 3 5.90
 .MODEL DR D ( IS=10.0f RS=1.99 N=3.00 )
 .ENDS
 
-*SRC=ZM4739A;DI_ZM4739A;Diodes;Zener <=10V; 9.10V  1.00W   Diodes Inc. 
+*SRC=ZM4739A;DI_ZM4739A;Diodes;Zener <=10V; 9.10V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4739A  1 2
 *        Terminals    A   K
@@ -8564,7 +9109,7 @@ VZ 2 3 6.80
 .MODEL DR D ( IS=9.05f RS=2.23 N=3.00 )
 .ENDS
 
-*SRC=ZM4740A;DI_ZM4740A;Diodes;Zener <=10V; 10.0V  1.00W   Diodes Inc. 
+*SRC=ZM4740A;DI_ZM4740A;Diodes;Zener <=10V; 10.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4740A  1 2
 *        Terminals    A   K
@@ -8576,7 +9121,7 @@ VZ 2 3 7.67
 .MODEL DR D ( IS=8.24f RS=3.89 N=3.00 )
 .ENDS
 
-*SRC=ZM4741A;DI_ZM4741A;Diodes;Zener 10V-50V; 11.0V  1.00W   Diodes Inc. 
+*SRC=ZM4741A;DI_ZM4741A;Diodes;Zener 10V-50V; 11.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4741A  1 2
 *        Terminals    A   K
@@ -8588,7 +9133,7 @@ VZ 2 3 8.66
 .MODEL DR D ( IS=7.49f RS=4.62 N=3.00 )
 .ENDS
 
-*SRC=ZM4742A;DI_ZM4742A;Diodes;Zener 10V-50V; 12.0V  1.00W   Diodes Inc. 
+*SRC=ZM4742A;DI_ZM4742A;Diodes;Zener 10V-50V; 12.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4742A  1 2
 *        Terminals    A   K
@@ -8600,7 +9145,7 @@ VZ 2 3 9.65
 .MODEL DR D ( IS=6.87f RS=5.30 N=3.00 )
 .ENDS
 
-*SRC=ZM4743A;DI_ZM4743A;Diodes;Zener 10V-50V; 13.0V  1.00W   Diodes Inc. 
+*SRC=ZM4743A;DI_ZM4743A;Diodes;Zener 10V-50V; 13.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4743A  1 2
 *        Terminals    A   K
@@ -8612,7 +9157,7 @@ VZ 2 3 10.7
 .MODEL DR D ( IS=6.34f RS=5.91 N=3.00 )
 .ENDS
 
-*SRC=ZM4744A;DI_ZM4744A;Diodes;Zener 10V-50V; 15.0V  1.00W   Diodes Inc. 
+*SRC=ZM4744A;DI_ZM4744A;Diodes;Zener 10V-50V; 15.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4744A  1 2
 *        Terminals    A   K
@@ -8624,7 +9169,7 @@ VZ 2 3 12.6
 .MODEL DR D ( IS=5.49f RS=9.43 N=3.00 )
 .ENDS
 
-*SRC=ZM4745A;DI_ZM4745A;Diodes;Zener 10V-50V; 16.0V  1.00W   Diodes Inc. 
+*SRC=ZM4745A;DI_ZM4745A;Diodes;Zener 10V-50V; 16.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4745A  1 2
 *        Terminals    A   K
@@ -8636,7 +9181,7 @@ VZ 2 3 13.6
 .MODEL DR D ( IS=5.15f RS=11.0 N=3.00 )
 .ENDS
 
-*SRC=ZM4746A;DI_ZM4746A;Diodes;Zener 10V-50V; 18.0V  1.00W   Diodes Inc. 
+*SRC=ZM4746A;DI_ZM4746A;Diodes;Zener 10V-50V; 18.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4746A  1 2
 *        Terminals    A   K
@@ -8648,7 +9193,7 @@ VZ 2 3 15.6
 .MODEL DR D ( IS=4.58f RS=14.4 N=3.00 )
 .ENDS
 
-*SRC=ZM4747A;DI_ZM4747A;Diodes;Zener 10V-50V; 20.0V  1.00W   Diodes Inc. 
+*SRC=ZM4747A;DI_ZM4747A;Diodes;Zener 10V-50V; 20.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4747A  1 2
 *        Terminals    A   K
@@ -8660,7 +9205,7 @@ VZ 2 3 17.6
 .MODEL DR D ( IS=4.12f RS=15.8 N=3.00 )
 .ENDS
 
-*SRC=ZM4748A;DI_ZM4748A;Diodes;Zener 10V-50V; 22.0V  1.00W   Diodes Inc. 
+*SRC=ZM4748A;DI_ZM4748A;Diodes;Zener 10V-50V; 22.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4748A  1 2
 *        Terminals    A   K
@@ -8672,7 +9217,7 @@ VZ 2 3 19.6
 .MODEL DR D ( IS=3.75f RS=16.2 N=3.00 )
 .ENDS
 
-*SRC=ZM4749A;DI_ZM4749A;Diodes;Zener 10V-50V; 24.0V  1.00W   Diodes Inc. 
+*SRC=ZM4749A;DI_ZM4749A;Diodes;Zener 10V-50V; 24.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4749A  1 2
 *        Terminals    A   K
@@ -8684,7 +9229,7 @@ VZ 2 3 21.6
 .MODEL DR D ( IS=3.43f RS=17.6 N=3.00 )
 .ENDS
 
-*SRC=ZM4750A;DI_ZM4750A;Diodes;Zener 10V-50V; 27.0V  1.00W   Diodes Inc. 
+*SRC=ZM4750A;DI_ZM4750A;Diodes;Zener 10V-50V; 27.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4750A  1 2
 *        Terminals    A   K
@@ -8696,7 +9241,7 @@ VZ 2 3 24.5
 .MODEL DR D ( IS=3.05f RS=26.8 N=3.00 )
 .ENDS
 
-*SRC=ZM4751A;DI_ZM4751A;Diodes;Zener 10V-50V; 30.0V  1.00W   Diodes Inc. 
+*SRC=ZM4751A;DI_ZM4751A;Diodes;Zener 10V-50V; 30.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4751A  1 2
 *        Terminals    A   K
@@ -8708,7 +9253,7 @@ VZ 2 3 27.5
 .MODEL DR D ( IS=2.75f RS=30.9 N=3.00 )
 .ENDS
 
-*SRC=ZM4752A;DI_ZM4752A;Diodes;Zener 10V-50V; 33.0V  1.00W   Diodes Inc. 
+*SRC=ZM4752A;DI_ZM4752A;Diodes;Zener 10V-50V; 33.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4752A  1 2
 *        Terminals    A   K
@@ -8720,7 +9265,7 @@ VZ 2 3 30.5
 .MODEL DR D ( IS=2.50f RS=34.6 N=3.00 )
 .ENDS
 
-*SRC=ZM4753A;DI_ZM4753A;Diodes;Zener 10V-50V; 36.0V  1.00W   Diodes Inc. 
+*SRC=ZM4753A;DI_ZM4753A;Diodes;Zener 10V-50V; 36.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4753A  1 2
 *        Terminals    A   K
@@ -8732,7 +9277,7 @@ VZ 2 3 33.5
 .MODEL DR D ( IS=2.29f RS=38.9 N=3.00 )
 .ENDS
 
-*SRC=ZM4754A;DI_ZM4754A;Diodes;Zener 10V-50V; 39.0V  1.00W   Diodes Inc. 
+*SRC=ZM4754A;DI_ZM4754A;Diodes;Zener 10V-50V; 39.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4754A  1 2
 *        Terminals    A   K
@@ -8744,7 +9289,7 @@ VZ 2 3 36.5
 .MODEL DR D ( IS=2.11f RS=48.0 N=3.00 )
 .ENDS
 
-*SRC=ZM4755A;DI_ZM4755A;Diodes;Zener 10V-50V; 43.0V  1.00W   Diodes Inc. 
+*SRC=ZM4755A;DI_ZM4755A;Diodes;Zener 10V-50V; 43.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4755A  1 2
 *        Terminals    A   K
@@ -8756,7 +9301,7 @@ VZ 2 3 40.4
 .MODEL DR D ( IS=1.92f RS=57.0 N=3.00 )
 .ENDS
 
-*SRC=ZM4756A;DI_ZM4756A;Diodes;Zener 10V-50V; 47.0V  1.00W   Diodes Inc. 
+*SRC=ZM4756A;DI_ZM4756A;Diodes;Zener 10V-50V; 47.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4756A  1 2
 *        Terminals    A   K
@@ -8768,7 +9313,7 @@ VZ 2 3 44.4
 .MODEL DR D ( IS=1.75f RS=65.9 N=3.00 )
 .ENDS
 
-*SRC=ZM4757A;DI_ZM4757A;Diodes;Zener >50V; 51.0V  1.00W   Diodes Inc. 
+*SRC=ZM4757A;DI_ZM4757A;Diodes;Zener >50V; 51.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4757A  1 2
 *        Terminals    A   K
@@ -8780,7 +9325,7 @@ VZ 2 3 48.4
 .MODEL DR D ( IS=1.62f RS=79.5 N=3.00 )
 .ENDS
 
-*SRC=ZM4758A;DI_ZM4758A;Diodes;Zener >50V; 56.0V  1.00W   Diodes Inc. 
+*SRC=ZM4758A;DI_ZM4758A;Diodes;Zener >50V; 56.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4758A  1 2
 *        Terminals    A   K
@@ -8792,7 +9337,7 @@ VZ 2 3 53.3
 .MODEL DR D ( IS=1.47f RS=92.7 N=3.00 )
 .ENDS
 
-*SRC=ZM4759A;DI_ZM4759A;Diodes;Zener >50V; 62.0V  1.00W   Diodes Inc. 
+*SRC=ZM4759A;DI_ZM4759A;Diodes;Zener >50V; 62.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4759A  1 2
 *        Terminals    A   K
@@ -8804,7 +9349,7 @@ VZ 2 3 59.3
 .MODEL DR D ( IS=1.33f RS=106 N=3.00 )
 .ENDS
 
-*SRC=ZM4760A;DI_ZM4760A;Diodes;Zener >50V; 68.0V  1.00W   Diodes Inc. 
+*SRC=ZM4760A;DI_ZM4760A;Diodes;Zener >50V; 68.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4760A  1 2
 *        Terminals    A   K
@@ -8816,7 +9361,7 @@ VZ 2 3 65.3
 .MODEL DR D ( IS=1.21f RS=129 N=3.00 )
 .ENDS
 
-*SRC=ZM4761A;DI_ZM4761A;Diodes;Zener >50V; 75.0V  1.00W   Diodes Inc. 
+*SRC=ZM4761A;DI_ZM4761A;Diodes;Zener >50V; 75.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4761A  1 2
 *        Terminals    A   K
@@ -8828,7 +9373,7 @@ VZ 2 3 72.3
 .MODEL DR D ( IS=1.10f RS=151 N=3.00 )
 .ENDS
 
-*SRC=ZM4762A;DI_ZM4762A;Diodes;Zener >50V; 82.0V  1.00W   Diodes Inc. 
+*SRC=ZM4762A;DI_ZM4762A;Diodes;Zener >50V; 82.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4762A  1 2
 *        Terminals    A   K
@@ -8840,7 +9385,7 @@ VZ 2 3 79.2
 .MODEL DR D ( IS=1.00f RS=174 N=3.00 )
 .ENDS
 
-*SRC=ZM4763A;DI_ZM4763A;Diodes;Zener >50V; 91.0V  1.00W   Diodes Inc. 
+*SRC=ZM4763A;DI_ZM4763A;Diodes;Zener >50V; 91.0V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4763A  1 2
 *        Terminals    A   K
@@ -8852,7 +9397,7 @@ VZ 2 3 88.1
 .MODEL DR D ( IS=9.05e-016 RS=222 N=3.00 )
 .ENDS
 
-*SRC=ZM4764A;DI_ZM4764A;Diodes;Zener >50V; 100V  1.00W   Diodes Inc. 
+*SRC=ZM4764A;DI_ZM4764A;Diodes;Zener >50V; 100V  1.00W   Diodes Inc.
 *SYM=HZEN
 .SUBCKT DI_ZM4764A  1 2
 *        Terminals    A   K
@@ -8876,26 +9421,26 @@ VZ 2 3 4.56
 .MODEL DR D ( IS=6.06f RS=1.15 N=2.97 )
 .ENDS
 
-*SRC=ZMM5260B;DI_ZMM5260B;Diodes;Zener 10V-50V; 43.0V  0.500W   Diodes Inc. Zener 
-*SYM=HZEN 
-.SUBCKT DI_ZMM5260B  1 2 
-*        Terminals    A   K 
-D1 1 2 DF 
-DZ 3 1 DR 
-VZ 2 3 40.7 
-.MODEL DF D ( IS=4.79p RS=1.24 N=1.10 
-+ CJO=26.0p VJ=1.00 M=0.330 TT=50.1n ) 
-.MODEL DR D ( IS=9.58e-016 RS=16.0 N=3.00 ) 
+*SRC=ZMM5260B;DI_ZMM5260B;Diodes;Zener 10V-50V; 43.0V  0.500W   Diodes Inc. Zener
+*SYM=HZEN
+.SUBCKT DI_ZMM5260B  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 40.7
+.MODEL DF D ( IS=4.79p RS=1.24 N=1.10
++ CJO=26.0p VJ=1.00 M=0.330 TT=50.1n )
+.MODEL DR D ( IS=9.58e-016 RS=16.0 N=3.00 )
 .ENDS
 
-*SRC=ZMM5262B;DI_ZMM5262B;Diodes;Zener >50V; 51.0V  0.500W   Diodes Inc. Zener 
-*SYM=HZEN 
-.SUBCKT DI_ZMM5262B  1 2 
-*        Terminals    A   K 
-D1 1 2 DF 
-DZ 3 1 DR 
-VZ 2 3 48.7 
-.MODEL DF D ( IS=4.04p RS=1.24 N=1.10 
-+ CJO=24.3p VJ=1.00 M=0.330 TT=50.1n ) 
-.MODEL DR D ( IS=8.08e-016 RS=30.1 N=3.00 ) 
+*SRC=ZMM5262B;DI_ZMM5262B;Diodes;Zener >50V; 51.0V  0.500W   Diodes Inc. Zener
+*SYM=HZEN
+.SUBCKT DI_ZMM5262B  1 2
+*        Terminals    A   K
+D1 1 2 DF
+DZ 3 1 DR
+VZ 2 3 48.7
+.MODEL DF D ( IS=4.04p RS=1.24 N=1.10
++ CJO=24.3p VJ=1.00 M=0.330 TT=50.1n )
+.MODEL DR D ( IS=8.08e-016 RS=30.1 N=3.00 )
 .ENDS


### PR DESCRIPTION
zener.lib didn't work with ngspice.
I tried to fix the syntactical errors in the file.
For some models I had to add a `.ENDS` statement manually. These models seem to be missing some information. Therefore I added some comments that these models are probably currupt.