### PR TITLE
Turn off nod patch envpath

### DIFF
--- a/Scripts/check_supported.py
+++ b/Scripts/check_supported.py
@@ -1,4 +1,4 @@
-#! /bin/env python
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 This script check if a given part is between the supported modules

--- a/Scripts/generate_supported.py
+++ b/Scripts/generate_supported.py
@@ -1,4 +1,4 @@
-#! /bin/env python
+#! /usr/bin/env python
 # # -*- coding: utf-8 -*-
 """
 This script generate Supported.txt and Supported.pickle


### PR DESCRIPTION
The executable binary of env is under /usr/bin/:
```bash
$ which env
/usr/bin/env
``` 
So I changed the two scripts and create this pull request.