### PR TITLE
Fix wrong comment token in DIODE2 library

### DIFF
--- a/Models/Diode/DIODE2.lib
+++ b/Models/Diode/DIODE2.lib
@@ -1,4 +1,4 @@
-# Unofficial LTSpice Wiki Page: http://ltwiki.org/index.php?title=Standard.dio Date of latest edit	02:34, 4 July 2013
+* Unofficial LTSpice Wiki Page: http://ltwiki.org/index.php?title=Standard.dio Date of latest edit	02:34, 4 July 2013
 
 .Model KD102A D(Is=21.66p N=1.28 Rs=1.79 Cjo=3.27p Tt=6.12e-9 M=0.32 Vj=0.71 Fc=0.5 Bv=250 IBv=1e-11 Eg=1.11 Xti=3 mfg=USSR type=silicon)
 .model KD102B D(Is=910.8f Rs=6.325 N=1 Xti=3 Eg=1.11 Bv=300.2 Ibv=1.521m Cjo=3.27p Vj=.71 M=.32 Fc=.5 Tt=6.12e-9 mfg=USSR type=silicon)


### PR DESCRIPTION
I wanted to simulate a simple circuit with a 1N4148 diode in KiCAD and the DIODE2 library containing it was broken when trying to run a simulation with ngspice. 